### PR TITLE
Add Git remote reassignment guide

### DIFF
--- a/CodexModuleMap.json
+++ b/CodexModuleMap.json
@@ -46,6 +46,13 @@
         "cmd.logWhisperJournal",
         "cmd.snapshotPartnerStatus"
       ]
+    },
+    "repoOps": {
+      "path": ".",
+      "repo": "hookahplus",
+      "codex": [
+        "ReflexArc_GitRemoteReassignment.codex.md"
+      ]
     }
   },
   "defaultModule": "pos"

--- a/ReflexArc_GitRemoteReassignment.codex.md
+++ b/ReflexArc_GitRemoteReassignment.codex.md
@@ -1,0 +1,14 @@
+# ReflexArc: Git Remote Reassignment
+
+## Purpose
+Document how to point a local Hookah+ project folder to the canonical repository.
+
+## Steps
+1. Ensure you're inside your local `Hookahplus` directory.
+2. Run the following command to set the `origin` remote:
+   ```bash
+   git remote set-url origin https://github.com/Trustbyrecon/Hookahplus.git
+   ```
+   If `origin` doesn't exist yet, use `git remote add` instead.
+
+The repository now tracks the canonical location and can pull or push updates accordingly.


### PR DESCRIPTION
## Summary
- document how to point the `origin` remote to the canonical Hookahplus repository
- register the guide in `CodexModuleMap.json` under the new `repoOps` module

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bc32d43388330a87de1c49290b11f