### PR TITLE
Update README for active netlify submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hookahplus
 
-Hookahplus aggregates several repositories for the Hookah+ project using Git submodules. The `backend`, `netlify` and future modules are linked as submodules so they remain separate repos while sharing a common root.
+Hookahplus aggregates several repositories for the Hookah+ project using Git submodules. Currently only the `netlify` site is linked as a submodule so it remains a separate repo while sharing a common root.
 
 ## Initializing Submodules
 After cloning this repository, pull in the linked modules with:
@@ -9,7 +9,7 @@ After cloning this repository, pull in the linked modules with:
 git submodule update --init --recursive
 ```
 
-This command fetches each submodule (for example `backend` and `netlify`) and checks out the appropriate commit.
+This command fetches the `netlify` submodule and checks out the appropriate commit.
 
 ## Command Dispatcher
 Utility tasks can be run via `cmd_dispatcher.py`. Invoke it with a command name to call the corresponding helper in `cmd/modules/reflex_ui.py`:


### PR DESCRIPTION
## Summary
- clarify that only the `netlify` submodule is active
- mention fetching the `netlify` submodule after cloning

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_688cfdf82e10833097e6812ed9807de4