### PR TITLE
Add dashboard package.json

### DIFF
--- a/app/dashboard/package.json
+++ b/app/dashboard/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hookahplus-dashboard",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "export": "next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json for the dashboard app with Next.js scripts and dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d03ef634083309e5e112924e83e20