### PR TITLE
Fix Netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
+base = "app/dashboard"
 publish = "out"
-command = "npm run export"
+command = "npm run build && npm run export"


### PR DESCRIPTION
## Summary
- fix Netlify build command to run `next build` before exporting

## Testing
- `npm install` *(fails: Build error occurred because no pages directory)*

------
https://chatgpt.com/codex/tasks/task_e_688d0751fd0c83308941dac44483dd07