### PR TITLE
Fix Netlify build by adding Next.js pages directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 dist/
 *.url
+
+# Node dependencies
+node_modules/
+app/dashboard/node_modules/
+app/dashboard/out/
+app/dashboard/.next/
+app/dashboard/package-lock.json

--- a/app/dashboard/next-env.d.ts
+++ b/app/dashboard/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/app/dashboard/next.config.js
+++ b/app/dashboard/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/app/dashboard/package.json
+++ b/app/dashboard/package.json
@@ -14,5 +14,10 @@
   },
   "engines": {
     "node": ">=16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.1.0",
+    "@types/react": "19.1.9",
+    "typescript": "5.9.2"
   }
 }

--- a/app/dashboard/pages/index.tsx
+++ b/app/dashboard/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Hookah+ Dashboard is Live</h1>;
+}

--- a/app/dashboard/tsconfig.json
+++ b/app/dashboard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create fallback `pages/index.tsx` and minimal Next.js config
- commit TypeScript defaults that Next expects
- ignore build artifacts

## Testing
- `npm run build` in `app/dashboard`
- `npm run export` in `app/dashboard`


------
https://chatgpt.com/codex/tasks/task_e_688d1d8a77d8833090a292c131182412