### PR TITLE
feat: add interactive homepage deployment command

### DIFF
--- a/cmd/modules/deployHomepageInteractive.py
+++ b/cmd/modules/deployHomepageInteractive.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def run():
+    homepage_content = """
+    import React from 'react';
+
+    export default function Home() {
+        return (
+            <main style={{ padding: '2rem' }}>
+                <h1>Welcome to Hookah+</h1>
+                <p>Your command center for flavor, flow, and loyalty intelligence.</p>
+                <div style={{ marginTop: '1rem' }}>
+                    <a href="/onboarding">Start Onboarding</a> | 
+                    <a href="/demo"> See a Demo</a> | 
+                    <a href="/live"> Join Live Session</a>
+                </div>
+            </main>
+        );
+    }
+    """
+
+    target_path = Path("app/page.tsx")
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(homepage_content.strip())
+
+    print("✅ Hookah+ interactive homepage deployed to app/page.tsx")

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -11,6 +11,7 @@ if MODULE_PATH not in sys.path:
     sys.path.insert(0, MODULE_PATH)
 
 import reflex_ui
+import deployHomepageInteractive as deploy_homepage_interactive
 
 
 def bundleDeployKit():
@@ -228,6 +229,12 @@ def releaseTeaserVideo():
     return "🎬 Teaser video released across marketing outlets"
 
 
+def deployHomepageInteractive():
+    """Deploy an interactive Next.js homepage to app/page.tsx."""
+    deploy_homepage_interactive.run()
+    return "✅ Hookah+ interactive homepage deployed to app/page.tsx"
+
+
 
 # Optional: Extend as new cmd.* actions are needed
 
@@ -253,7 +260,8 @@ COMMANDS = {
     "alignMainPortalUI": alignMainPortalUI,
     "registerLoungeConfig": registerLoungeConfig,
     "pushPressKit": pushPressKit,
-    "releaseTeaserVideo": releaseTeaserVideo
+    "releaseTeaserVideo": releaseTeaserVideo,
+    "deployHomepageInteractive": deployHomepageInteractive
 }
 
 


### PR DESCRIPTION
## Summary
- add deployHomepageInteractive module to generate Next.js landing page
- wire command into dispatcher for CLI/SDK usage

## Testing
- `python - <<'PY'
import cmd_dispatcher as cmd
res = cmd.deployHomepageInteractive()
print('Result:', res)
PY`
- `npm test` (fails: Missing script: "test")
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f97883e848330b263cf6f7381d08c