### PR TITLE
feat: add interactive homepage deployment command

### DIFF
--- a/CodexModuleMap.json
+++ b/CodexModuleMap.json
@@ -1,4 +1,8 @@
 {
+  "cmd.deployHomepageInteractive": {
+    "path": "cmd/modules/deployHomepageInteractive.py",
+    "description": "Injects a Next.js homepage with links for onboarding, demo, and live sessions."
+  },
   "cmd.fireSession": {
     "description": "Trigger a new Hookah+ session (start timer, log metadata, attach flavor config).",
     "path": "cmd/modules/fireSession.cmd.js",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Home() {
+    return (
+        <main style={{ padding: '2rem' }}>
+            <h1>Welcome to Hookah+</h1>
+            <p>Your command center for flavor, flow, and loyalty intelligence.</p>
+            <div style={{ marginTop: '1rem' }}>
+                <a href='/onboarding'>Start Onboarding</a> | 
+                <a href='/demo'>See a Demo</a> | 
+                <a href='/live'>Join Live Session</a>
+            </div>
+        </main>
+    );
+}

--- a/cmd/modules/deployHomepageInteractive.py
+++ b/cmd/modules/deployHomepageInteractive.py
@@ -1,7 +1,6 @@
-from pathlib import Path
-
-
 def run():
+    from pathlib import Path
+    import textwrap
     homepage_content = """
     import React from 'react';
 
@@ -11,9 +10,9 @@ def run():
                 <h1>Welcome to Hookah+</h1>
                 <p>Your command center for flavor, flow, and loyalty intelligence.</p>
                 <div style={{ marginTop: '1rem' }}>
-                    <a href="/onboarding">Start Onboarding</a> | 
-                    <a href="/demo"> See a Demo</a> | 
-                    <a href="/live"> Join Live Session</a>
+                    <a href='/onboarding'>Start Onboarding</a> | 
+                    <a href='/demo'>See a Demo</a> | 
+                    <a href='/live'>Join Live Session</a>
                 </div>
             </main>
         );
@@ -22,6 +21,6 @@ def run():
 
     target_path = Path("app/page.tsx")
     target_path.parent.mkdir(parents=True, exist_ok=True)
-    target_path.write_text(homepage_content.strip())
+    target_path.write_text(textwrap.dedent(homepage_content).strip())
 
-    return "✅ Hookah+ interactive homepage deployed to app/page.tsx"
+    print("✅ Hookah+ interactive homepage deployed to app/page.tsx")

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -14,11 +14,6 @@ import reflex_ui
 import deployHomepageInteractive as deploy_homepage_interactive
 
 
-def deployHomepageInteractive():
-    """Generate a minimal interactive homepage in app/page.tsx."""
-    return deploy_homepage_interactive.run()
-
-
 def bundleDeployKit():
     """
     Bundles the Hookah+ deploy kit: React UI, YAML configs, and Netlify-ready build.
@@ -235,9 +230,7 @@ def releaseTeaserVideo():
 
 
 def deployHomepageInteractive():
-    """Deploy an interactive Next.js homepage to app/page.tsx."""
     deploy_homepage_interactive.run()
-    return "✅ Hookah+ interactive homepage deployed to app/page.tsx"
 
 
 


### PR DESCRIPTION
## Summary
- add module to generate interactive Next.js homepage
- expose deployHomepageInteractive command and map in CodexModuleMap
- include generated `app/page.tsx` with onboarding, demo, and live session links

## Testing
- `python -c "import cmd_dispatcher as cmd; cmd.deployHomepageInteractive()"`


------
https://chatgpt.com/codex/tasks/task_e_688f9bc192a08330b73b26c45a50204d