### PR TITLE
Add flavor selector with metadata tracking

### DIFF
--- a/app/flavors/SelectorAphrodite.tsx
+++ b/app/flavors/SelectorAphrodite.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Flavor {
+  name: string;
+  notes: string;
+}
+
+interface Props {
+  flavors: Flavor[];
+}
+
+export default function SelectorAphrodite({ flavors }: Props) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [metrics, setMetrics] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    const stored = localStorage.getItem('flavor-metrics');
+    if (stored) {
+      setMetrics(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('flavor-metrics', JSON.stringify(metrics));
+  }, [metrics]);
+
+  const toggleFlavor = (name: string) => {
+    setSelected((prev) =>
+      prev.includes(name) ? prev.filter((f) => f !== name) : [...prev, name]
+    );
+    setMetrics((prev) => ({
+      ...prev,
+      [name]: (prev[name] || 0) + 1,
+    }));
+  };
+
+  const metadata = {
+    stripe: { flavors: selected },
+    loyalty: { points: selected.length * 5 },
+  };
+
+  const mixTags = selected.join(', ');
+
+  return (
+    <div className="mt-4">
+      <ul className="space-y-2">
+        {flavors.map((flavor) => (
+          <li key={flavor.name}>
+            <button
+              onClick={() => toggleFlavor(flavor.name)}
+              className={`px-4 py-2 border rounded ${
+                selected.includes(flavor.name)
+                  ? 'bg-cyan-600 text-white'
+                  : 'bg-zinc-800 text-zinc-200'
+              }`}
+            >
+              {flavor.name}
+            </button>
+            <span className="ml-2 text-sm text-zinc-400">{flavor.notes}</span>
+          </li>
+        ))}
+      </ul>
+
+      {selected.length > 0 && (
+        <div className="mt-6 space-y-4">
+          <div>
+            <h3 className="font-semibold">Suggested Mix Tags</h3>
+            <p className="text-sm text-zinc-400">{mixTags}</p>
+          </div>
+          <div>
+            <h3 className="font-semibold">Metadata Injection</h3>
+            <pre className="text-xs bg-zinc-900 p-2 rounded">
+              {JSON.stringify(metadata, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <h3 className="font-semibold">Popularity Metrics</h3>
+            <ul className="text-sm text-zinc-400">
+              {Object.entries(metrics).map(([name, count]) => (
+                <li key={name}>{name}: {count} taps</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/flavors/page.tsx
+++ b/app/flavors/page.tsx
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import SelectorAphrodite from './SelectorAphrodite';
+
+export default function FlavorsPage() {
+  const filePath = path.join(process.cwd(), 'data', 'flavor_profiles.yaml');
+  const fileContents = fs.readFileSync(filePath, 'utf8');
+  const flavors = yaml.load(fileContents) as { name: string; notes: string }[];
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">Flavor Selector</h1>
+      <SelectorAphrodite flavors={flavors} />
+    </div>
+  );
+}

--- a/data/flavor_profiles.yaml
+++ b/data/flavor_profiles.yaml
@@ -1,0 +1,6 @@
+- name: Mint Blast
+  notes: Cooling mint with crisp finish
+- name: Double Apple
+  notes: Classic apple with anise
+- name: Blueberry Mist
+  notes: Sweet blueberry with smooth smoke

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
## Summary
- add flavor selector page powered by YAML flavor profiles
- track taps to suggest mix tags and generate Stripe/loyalty metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68908913b3488330ade4825c10854003