### PR TITLE
Add Chronos_ΔKairos agent for session timing

### DIFF
--- a/CodexModuleMap.json
+++ b/CodexModuleMap.json
@@ -52,5 +52,10 @@
     "description": "Log and realign the deploy chain state across Codex, Netlify, and GitHub PR history.",
     "path": "cmd/modules/triggerReflexDeployChainRealignment.cmd.js",
     "tags": ["reflex", "deploy", "log"]
+  },
+  "codex.chronosKairos": {
+    "description": "Agent Chronos_ΔKairos for session timing and reflex decay tracking.",
+    "path": "codex/Modules/2025-08-02_chronos_kairos.ts",
+    "tags": ["session", "timer", "reflex"]
   }
 }

--- a/codex/Modules/2025-08-02_chronos_kairos.ts
+++ b/codex/Modules/2025-08-02_chronos_kairos.ts
@@ -1,0 +1,87 @@
+import fs from "fs";
+import DecaySensor from "./2025-08-02_decay_sensor";
+
+interface SessionConfig {
+  decay_rate?: number;
+  default_duration?: number;
+}
+
+export interface ReceiptMetadata {
+  durationMs: number;
+}
+
+export interface TrustLogEntry {
+  timestamp: number;
+  event: string;
+  durationMs?: number;
+}
+
+export class ChronosKairos {
+  private startTime?: number;
+  private elapsed = 0;
+  private trustLog: TrustLogEntry[] = [];
+  private config: SessionConfig;
+  private decaySensor: DecaySensor;
+
+  constructor(configPath: string) {
+    this.config = this.loadConfig(configPath);
+    const rate = this.config.decay_rate ?? 0.1;
+    this.decaySensor = new DecaySensor(rate);
+  }
+
+  private loadConfig(path: string): SessionConfig {
+    const raw = fs.readFileSync(path, "utf8");
+    const cfg: SessionConfig = {};
+    raw.split(/\r?\n/).forEach((line) => {
+      const [key, value] = line.split(":").map((s) => s.trim());
+      if (key && value) {
+        const num = Number(value);
+        cfg[key as keyof SessionConfig] = isNaN(num) ? value as any : num;
+      }
+    });
+    return cfg;
+  }
+
+  checkIn(customerId: string) {
+    this.trustLog.push({ timestamp: Date.now(), event: `check-in:${customerId}` });
+    this.start();
+  }
+
+  start() {
+    if (this.startTime) return;
+    this.startTime = Date.now();
+    this.trustLog.push({ timestamp: this.startTime, event: "start" });
+  }
+
+  pause() {
+    if (!this.startTime) return;
+    const now = Date.now();
+    this.elapsed += now - this.startTime;
+    this.trustLog.push({ timestamp: now, event: "pause", durationMs: this.elapsed });
+    this.startTime = undefined;
+  }
+
+  end() {
+    if (this.startTime) {
+      const now = Date.now();
+      this.elapsed += now - this.startTime;
+      this.trustLog.push({ timestamp: now, event: "end", durationMs: this.elapsed });
+      this.startTime = undefined;
+    }
+    const duration = this.elapsed;
+    return {
+      receipt: this.buildReceipt(duration),
+      trustLog: this.trustLog,
+    };
+  }
+
+  private buildReceipt(duration: number): ReceiptMetadata {
+    return { durationMs: duration };
+  }
+
+  reflexLevel(initial: number): number {
+    return this.decaySensor.sense(initial);
+  }
+}
+
+export default ChronosKairos;

--- a/configs/session_config.yaml
+++ b/configs/session_config.yaml
@@ -1,0 +1,2 @@
+decay_rate: 0.05
+default_duration: 3600


### PR DESCRIPTION
## Summary
- add Chronos_ΔKairos TypeScript module with start/pause/end timer controls and reflex decay helper
- introduce session_config.yaml for configuring default duration and decay rate
- register the agent in CodexModuleMap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689089633b1083308fbb7b5dfcabfcae