### PR TITLE
Add Moodbook design tokens and reflex components

### DIFF
--- a/components/ReflexCard.tsx
+++ b/components/ReflexCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ReflexCardProps {
+  title: string;
+  description: string;
+  cta: string;
+}
+
+export const ReflexCard: React.FC<ReflexCardProps> = ({ title, description, cta }) => {
+  return (
+    <div className="bg-charcoal text-goldLumen rounded-2xl p-6 shadow-xl hover:shadow-2xl transition-all">
+      <div className="text-mystic mb-2">{/* Icon placeholder */}</div>
+      <h2 className="font-display text-xl mb-2">{title}</h2>
+      <p className="font-sans text-base">{description}</p>
+      <button className="bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded">{cta}</button>
+    </div>
+  );
+};
+
+export default ReflexCard;

--- a/moodbook-font-stack.ts
+++ b/moodbook-font-stack.ts
@@ -1,0 +1,7 @@
+export const MoodFonts = {
+  display: 'Playfair Display',
+  body: 'Inter',
+  fallback: 'system-ui',
+};
+
+export default MoodFonts;

--- a/moodbook-theme.ts
+++ b/moodbook-theme.ts
@@ -1,0 +1,9 @@
+export const MoodColors = {
+  charcoal: '#1B1B1E',      // Base Surface
+  ember: '#D35930',         // Action Accent
+  mystic: '#8E79B9',        // Loyalty & Whisper
+  deepMoss: '#486964',      // Flavor Flow
+  goldLumen: '#E8D7B1',     // Typography, Highlights
+};
+
+export default MoodColors;

--- a/sessionIgnition.ts
+++ b/sessionIgnition.ts
@@ -1,0 +1,31 @@
+export interface SessionFlow {
+  live: boolean;
+}
+
+export interface FlavorState {
+  mix: boolean;
+}
+
+export interface LoyaltyState {
+  preview: boolean;
+}
+
+export function triggerIgnitionModal() {
+  console.log("You've lit the session path. Loyalty, memory, and reflex are now live. Watch your EP Score evolve.");
+}
+
+export function updateEPScore(score: number) {
+  console.log(`EP Score updated to ${score}`);
+}
+
+export function reflexPulseEffect(effect: string) {
+  console.log(`Reflex pulse: ${effect}`);
+}
+
+export function sessionIgnition(sessionFlow: SessionFlow, flavor: FlavorState, loyalty: LoyaltyState) {
+  if (sessionFlow.live && flavor.mix && loyalty.preview) {
+    triggerIgnitionModal();
+    updateEPScore(9.2);
+    reflexPulseEffect('aura-flare');
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,7 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --font-display: 'Playfair Display', serif;
+  --font-sans: 'Inter', sans-serif;
+
+  --text-xl: 48px;
+  --text-lg: 28px;
+  --text-base: 18px;
+  --text-sm: 14px;
+}
+
 body {
   background-color: #ffffff;
   color: #111827;
+  font-family: var(--font-sans);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,19 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        charcoal: '#1B1B1E',
+        ember: '#D35930',
+        mystic: '#8E79B9',
+        deepMoss: '#486964',
+        goldLumen: '#E8D7B1',
+      },
+      fontFamily: {
+        display: ['var(--font-display)', 'serif'],
+        sans: ['var(--font-sans)', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Moodbook color and font tokens
- style globals and tailwind to expose new theme
- implement ReflexCard and session ignition helper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890a958d8c48330913802c6b3bc1763