### PR TITLE
Add trust ops configs and reflex log hooks

### DIFF
--- a/"b/config/trustops/agents/DesignFlare_\316\22404/mission.yaml"
+++ b/"b/config/trustops/agents/DesignFlare_\316\22404/mission.yaml"
@@ -1,0 +1,9 @@
+agent: DesignFlare_Δ04
+permissions:
+  - read: /ui/theme/
+  - write: /ui/theme/colors.ts, /ui/components/ReflexCard.tsx
+  - synthesize: moodboard, codex
+actions:
+  - respond to: cmd.igniteDesignFlare()
+  - trigger: MoodbookOverlay
+  - export: style-guide.md, moodbook.zip

--- a/components/FlavorSelector.tsx
+++ b/components/FlavorSelector.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+declare const reflex:
+  | { logEvent: (event: string, payload: Record<string, unknown>) => void }
+  | undefined;
+
 interface Props {
   value: string;
   onChange: (value: string) => void;
@@ -8,13 +12,21 @@ interface Props {
 export default function FlavorSelector({ value, onChange }: Props) {
   const flavors = ['Mint', 'Double Apple', 'Grape'];
 
+  const handleChange = (newValue: string) => {
+    reflex?.logEvent('flavor_selected', {
+      flavor: newValue,
+      timestamp: Date.now(),
+    });
+    onChange(newValue);
+  };
+
   return (
     <div className="mb-4">
       <label className="block text-sm font-medium mb-1">Flavor</label>
       <select
         className="w-full p-2 bg-gray-800 text-white"
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => handleChange(e.target.value)}
       >
         {flavors.map((f) => (
           <option key={f} value={f}>

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -2,6 +2,10 @@ import React, { useState } from 'react';
 import FlavorSelector from './FlavorSelector';
 import TimerControl from './TimerControl';
 
+declare const reflex:
+  | { logEvent: (event: string, payload: Record<string, unknown>) => void }
+  | undefined;
+
 interface Props {
   onComplete: () => void;
 }
@@ -18,7 +22,15 @@ export default function OnboardingModal({ onComplete }: Props) {
         <TimerControl value={timer} onChange={setTimer} />
         <button
           className="mt-4 w-full bg-blue-600 hover:bg-blue-500 text-white py-2 px-4 rounded"
-          onClick={onComplete}
+          onClick={() => {
+            reflex?.logEvent('loyalty_triggered', {
+              flavor,
+              mix: { timer },
+              epScore: 0,
+              timestamp: Date.now(),
+            });
+            onComplete();
+          }}
         >
           Save
         </button>

--- a/config/trustops/agents/Alie/mission.yaml
+++ b/config/trustops/agents/Alie/mission.yaml
@@ -1,0 +1,9 @@
+agent: Alie
+permissions:
+  - read: /sessions/
+  - write: /SessionNotes, /ReflexPromptLogs
+  - synthesize: agent insights, trust gaps
+actions:
+  - respond to: reflection toggles, whisper recall
+  - seed: journaling prompts, recovery loops
+  - forecast: trust resonance & drift

--- a/config/trustops/hooks/environment-access.yaml
+++ b/config/trustops/hooks/environment-access.yaml
@@ -1,0 +1,8 @@
+environment:
+  - repo_access: true
+  - netlify_sync: true
+  - image_scrape: allowed
+  - api_post: flavor_session_ingest, loyalty_log_submit
+agents:
+  - DesignFlare_Δ04: [ repo_access, image_scrape ]
+  - Alie: [ netlify_sync, api_post ]

--- a/config/trustops/session/ReflexLog.yaml
+++ b/config/trustops/session/ReflexLog.yaml
@@ -1,0 +1,10 @@
+capture_events:
+  - session_started
+  - flavor_selected
+  - loyalty_triggered
+  - whisper_prompted
+log_targets:
+  - GhostLog.yaml
+  - ReflexScoreDelta.json
+  - SessionNotes.private
+status: "live"


### PR DESCRIPTION
## Summary
- add mission briefs for DesignFlare_Δ04 and Alie
- configure environment access and session log capture
- log flavor selections and loyalty triggers in React components

## Testing
- `python cmd_dispatcher.py sealVisualToData` *(fails: Unknown command)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ad414fa88330b9abd503cad66178