### PR TITLE
Add TrustOps CLI expansion pack configuration

### DIFF
--- a/"b/\316\224Agentic_MOAT_CLI.yaml"
+++ b/"b/\316\224Agentic_MOAT_CLI.yaml"
@@ -1,0 +1,61 @@
+# Agentic CLI Expansion Pack for TrustOps Moat
+version: 1.0
+codename: ΔAgentic_MOAT_CLI
+timestamp: 2025-08-04T08:00Z
+
+commands:
+  - id: enableWhisperFeedback
+    description: Activate user-facing feedback modal with Reflex logging
+    trigger: ui.lounge.feedback
+    log_target: WhisperJournal
+    requires: WhisperOverlay, TrustInput
+
+  - id: routeToWhisperJournal
+    description: Pipe feedback directly into Whisper Memory Panel and Journal export
+    path: /trust/whispers/feedback
+    integration: export_to_GitHub every 3 entries
+
+  - id: enableAutonomy
+    args:
+      - agent: [DesignFlare_Δ04, Alie]
+    permissions:
+      - DesignFlare_Δ04: synthesize, layout, moodbook
+      - Alie: memoryForecast, whisperPing, trustAssist
+    timeout: 90min windows per activation
+
+  - id: simulateTrustDecay
+    args:
+      - sessionFlow: string
+      - interruptAt: string
+    output: ReflexScoreForecast
+    mode: predictive or reactive
+
+  - id: projectReflexScoreCurve
+    args:
+      - variant: string
+      - loyaltyEvent: boolean
+    output: curveGraph + EPScoreDelta
+
+  - id: snapshotMemoryBloom
+    output:
+      - bloomFile: MemoryBloom_ΔYYYYMMDD.json
+      - voiceEcho: AlethiaTag
+    trigger: cmd.logPulse("Trust Lock")
+
+  - id: restoreMemoryBloom
+    args:
+      - bloomFile: MemoryBloom_ΔYYYYMMDD.json
+    effects: Restore Reflex State, UI overlays, EP anchor
+
+  - id: activateDriftWatcher
+    targets:
+      - pricingLogic
+      - loyaltyEventMismatch
+      - visualFunctionSync
+    trigger: anomalyDetected → cmd.alertOnAnomaly(type)
+
+  - id: alertOnAnomaly
+    args:
+      - type: [loyaltyMismatch, pricingDrift, overlayFail]
+    integration: EP Flag + Alie Trust Report
+    notify: Visual Alert Panel


### PR DESCRIPTION
## Summary
- add ΔAgentic_MOAT_CLI.yaml defining TrustOps CLI expansion commands for feedback logging, agent autonomy, memory bloom management, and anomaly alerts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b1ce1a6c833093ff42198e3deb0a