### PR TITLE
Align home, flavor, and demo screens with Moodbook theme

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -10,6 +10,7 @@ export default function DemoPage() {
         <h1 className="text-4xl font-extrabold tracking-tight">
           🎬 Demo Preview Portal
         </h1>
+        <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
         <p className="mt-4 text-lg text-zinc-300">
           Explore what Hookah+ can unlock in your lounge. This preview simulates real-time session flow, flavor memory, and loyalty intelligence.
         </p>
@@ -18,7 +19,10 @@ export default function DemoPage() {
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🕹️ Live Session Simulation</h2>
             <p className="mt-2 text-zinc-400">Preview how customers engage, order, and unlock flavor points.</p>
-            <Link href="/live" className="mt-4 inline-block text-cyan-400 hover:underline">
+            <Link
+              href="/live"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+            >
               Launch Live Session →
             </Link>
           </div>
@@ -26,7 +30,10 @@ export default function DemoPage() {
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🌬️ Flavor Mix Journey</h2>
             <p className="mt-2 text-zinc-400">Explore dynamic flavor combinations and their loyalty effects.</p>
-            <Link href="/flavors" className="mt-4 inline-block text-cyan-400 hover:underline">
+            <Link
+              href="/flavors"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+            >
               Try Flavor Flow →
             </Link>
           </div>
@@ -34,7 +41,10 @@ export default function DemoPage() {
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">📈 Loyalty Dashboard Preview</h2>
             <p className="mt-2 text-zinc-400">View how Hookah+ tracks, scores, and rewards session behavior.</p>
-            <Link href="/loyalty" className="mt-4 inline-block text-cyan-400 hover:underline">
+            <Link
+              href="/loyalty"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+            >
               View Loyalty Portal →
             </Link>
           </div>

--- a/app/flavors/SelectorAphrodite.tsx
+++ b/app/flavors/SelectorAphrodite.tsx
@@ -26,6 +26,12 @@ export default function SelectorAphrodite({ flavors }: Props) {
     localStorage.setItem('flavor-metrics', JSON.stringify(metrics));
   }, [metrics]);
 
+  useEffect(() => {
+    if (selected.length > 0) {
+      alert('Session memory secured.');
+    }
+  }, [selected]);
+
   const toggleFlavor = (name: string) => {
     setSelected((prev) =>
       prev.includes(name) ? prev.filter((f) => f !== name) : [...prev, name]
@@ -36,12 +42,6 @@ export default function SelectorAphrodite({ flavors }: Props) {
     }));
   };
 
-  const metadata = {
-    stripe: { flavors: selected },
-    loyalty: { points: selected.length * 5 },
-  };
-
-  const mixTags = selected.join(', ');
 
   return (
     <div className="mt-4">
@@ -65,24 +65,7 @@ export default function SelectorAphrodite({ flavors }: Props) {
 
       {selected.length > 0 && (
         <div className="mt-6 space-y-4">
-          <div>
-            <h3 className="font-semibold">Suggested Mix Tags</h3>
-            <p className="text-sm text-zinc-400">{mixTags}</p>
-          </div>
-          <div>
-            <h3 className="font-semibold">Metadata Injection</h3>
-            <pre className="text-xs bg-zinc-900 p-2 rounded">
-              {JSON.stringify(metadata, null, 2)}
-            </pre>
-          </div>
-          <div>
-            <h3 className="font-semibold">Popularity Metrics</h3>
-            <ul className="text-sm text-zinc-400">
-              {Object.entries(metrics).map(([name, count]) => (
-                <li key={name}>{name}: {count} taps</li>
-              ))}
-            </ul>
-          </div>
+          <p className="text-mystic">Your loyalty flavor has been saved.</p>
         </div>
       )}
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head />
-      <body className="min-h-screen">{children}</body>
+      <body className="min-h-screen bg-charcoal text-goldLumen">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,41 @@
 import React from 'react';
-import Link from 'next/link';
+import ReflexCard from '../components/ReflexCard';
+import WhisperTrigger from '../components/WhisperTrigger';
 
 export default function Home() {
+  const cards = [
+    {
+      title: 'Onboarding',
+      description: 'Begin the journey and align your lounge.',
+      cta: 'Start Onboarding',
+      href: '/onboarding',
+    },
+    {
+      title: 'Demo',
+      description: 'Preview capabilities and flow.',
+      cta: 'See a Demo',
+      href: '/demo',
+    },
+    {
+      title: 'Live Session',
+      description: 'Engage with a real-time session.',
+      cta: 'Join Live Session',
+      href: '/live',
+    },
+  ];
+
   return (
-    <main className="p-8">
-      <h1 className="text-3xl font-bold">Welcome to Hookah+</h1>
-      <p className="mt-2">Your command center for flavor, flow, and loyalty intelligence.</p>
-      <div className="mt-4 space-x-4">
-        <Link href="/onboarding">Start Onboarding</Link>
-        <Link href="/demo">See a Demo</Link>
-        <Link href="/live">Join Live Session</Link>
+    <main className="p-8 flex flex-col items-center space-y-8">
+      <h1 className="text-3xl font-display">Welcome to Hookah+</h1>
+      <p className="mt-2 text-center max-w-xl">
+        Your command center for flavor, flow, and loyalty intelligence.
+      </p>
+      <div className="grid gap-6 md:grid-cols-3">
+        {cards.map((card) => (
+          <ReflexCard key={card.href} {...card} />
+        ))}
       </div>
+      <WhisperTrigger />
     </main>
   );
 }

--- a/components/ReflexCard.tsx
+++ b/components/ReflexCard.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
+import Link from 'next/link';
 
 interface ReflexCardProps {
   title: string;
   description: string;
   cta: string;
+  href?: string;
 }
 
-export const ReflexCard: React.FC<ReflexCardProps> = ({ title, description, cta }) => {
+export const ReflexCard: React.FC<ReflexCardProps> = ({ title, description, cta, href }) => {
   return (
     <div className="bg-charcoal text-goldLumen rounded-2xl p-6 shadow-xl hover:shadow-2xl transition-all">
       <div className="text-mystic mb-2">{/* Icon placeholder */}</div>
       <h2 className="font-display text-xl mb-2">{title}</h2>
       <p className="font-sans text-base">{description}</p>
-      <button className="bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded">{cta}</button>
+      {href ? (
+        <Link
+          href={href}
+          className="inline-block bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded"
+        >
+          {cta}
+        </Link>
+      ) : (
+        <button className="bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded">{cta}</button>
+      )}
     </div>
   );
 };

--- a/components/WhisperTrigger.tsx
+++ b/components/WhisperTrigger.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export default function WhisperTrigger() {
+  return (
+    <button
+      onClick={() => {
+        alert('Alie intro whisper pending.');
+      }}
+      className="mt-8 px-6 py-3 bg-mystic text-charcoal rounded-full animate-pulse hover:animate-none transition transform hover:scale-105"
+    >
+      Play Alie’s Intro
+    </button>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,7 +13,11 @@
 }
 
 body {
-  background-color: #ffffff;
-  color: #111827;
+  background-color: #1B1B1E; /* charcoal */
+  color: #E8D7B1; /* goldLumen */
   font-family: var(--font-sans);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
 }


### PR DESCRIPTION
## Summary
- replace homepage links with ReflexCard grid and add a “Play Alie’s Intro” whisper trigger
- hide flavor metadata and whisper confirmation when a flavor is saved
- apply Moodbook colors/fonts globally and add glow/flare animations on demo links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890bdb1b1688330a0f0efd0e0cba3af