### PR TITLE
feat: add flavor flow dashboard prototype

### DIFF
--- a/components/FlavorBadge.tsx
+++ b/components/FlavorBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface Props {
+  flavor: string; // e.g., "Mint" or "Lemon"
+}
+
+// Maps flavors to emoji for quick visual recognition
+const flavorEmoji: Record<string, string> = {
+  Mint: '🌿',
+  Lemon: '🍋',
+  Watermelon: '🍉',
+  Grape: '🍇',
+};
+
+export default function FlavorBadge({ flavor }: Props) {
+  return (
+    <span className="inline-flex items-center px-2 py-1 bg-gray-800 rounded text-sm mr-1" title={flavor}>
+      <span className="mr-1">{flavorEmoji[flavor] || '🍓'}</span>
+      {flavor}
+    </span>
+  );
+}

--- a/components/OwnerMetrics.tsx
+++ b/components/OwnerMetrics.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Session } from './SessionCard';
+
+export default function OwnerMetrics({ sessions }: { sessions: Session[] }) {
+  const flavorRevenue: Record<string, number> = {};
+  let burnouts = 0;
+  let refills = 0;
+  sessions.forEach((s) => {
+    const price = s.flavors.length * 15 + s.refills * 5;
+    s.flavors.forEach((f) => {
+      flavorRevenue[f] = (flavorRevenue[f] || 0) + price / s.flavors.length;
+    });
+    burnouts += s.notes?.filter((n) => n === 'burnout').length || 0;
+    refills += s.refills;
+  });
+  const totalRevenue = Object.values(flavorRevenue).reduce((a, b) => a + b, 0);
+  const ratio = refills > 0 ? (burnouts / refills).toFixed(2) : '0';
+  return (
+    <div className="p-4 bg-gray-900 rounded text-white mb-4">
+      <h2 className="font-bold mb-2">Owner Metrics</h2>
+      <div className="text-sm mb-2">Total Revenue: ${totalRevenue.toFixed(2)}</div>
+      {Object.entries(flavorRevenue).map(([flavor, revenue]) => (
+        <div key={flavor} className="text-sm">
+          {flavor}: ${revenue.toFixed(2)}
+        </div>
+      ))}
+      <div className="text-sm mt-2">Burnout/Refill Ratio: {ratio}</div>
+    </div>
+  );
+}

--- a/components/SessionAnalytics.tsx
+++ b/components/SessionAnalytics.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Session } from './SessionCard';
+
+export default function SessionAnalytics({ sessions }: { sessions: Session[] }) {
+  const now = Date.now();
+  const flavorDurations: Record<string, number[]> = {};
+  sessions.forEach((s) => {
+    const duration = (now - s.startTime) / 60000;
+    s.flavors.forEach((f) => {
+      if (!flavorDurations[f]) flavorDurations[f] = [];
+      flavorDurations[f].push(duration);
+    });
+  });
+  const avgFlavorDurations = Object.entries(flavorDurations).map(([flavor, list]) => ({
+    flavor,
+    avg: list.reduce((a, b) => a + b, 0) / list.length,
+  }));
+  const avgRefills =
+    sessions.reduce((sum, s) => sum + (s.refills || 0), 0) / sessions.length;
+  return (
+    <div className="p-4 bg-gray-900 rounded text-white mb-4">
+      <h2 className="font-bold mb-2">Manager Analytics</h2>
+      <div className="text-sm mb-2">
+        Avg Refills/Session: {avgRefills.toFixed(1)}
+      </div>
+      {avgFlavorDurations.map(({ flavor, avg }) => (
+        <div key={flavor} className="text-sm">
+          {flavor}: {avg.toFixed(1)} mins avg
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import FlavorBadge from './FlavorBadge';
+
+type ViewMode = 'staff' | 'manager' | 'owner';
+
+export interface Session {
+  id: number;
+  table: string;
+  flavors: string[];
+  startTime: number; // ms timestamp
+  refills: number;
+  notes?: string[];
+}
+
+interface Props {
+  session: Session;
+  mode: ViewMode;
+  onRefill: (id: number) => void;
+  onAddNote: (id: number, note: string) => void;
+  onBurnout: (id: number) => void;
+}
+
+function getStatus(elapsed: number) {
+  if (elapsed >= 70) return { label: 'Burnt Out', tone: 'bg-red-700' };
+  if (elapsed >= 45) return { label: 'Shisha Low', tone: 'bg-orange-600' };
+  if (elapsed >= 25) return { label: 'Coal Low', tone: 'bg-yellow-600' };
+  return { label: 'Active', tone: 'bg-green-700' };
+}
+
+export default function SessionCard({ session, mode, onRefill, onAddNote, onBurnout }: Props) {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const tick = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const elapsedMin = (now - session.startTime) / 60000;
+  const elapsedSec = Math.floor((now - session.startTime) / 1000) % 60;
+  const status = getStatus(elapsedMin);
+
+  useEffect(() => {
+    if (status.label === 'Burnt Out') {
+      onBurnout(session.id);
+    }
+  }, [status.label, onBurnout, session.id]);
+  const price = session.flavors.length * 15 + session.refills * 5;
+
+  return (
+    <div className={`p-4 rounded-xl text-white mb-4 ${status.tone}`}>
+      <h3 className="font-bold text-lg mb-1">Table {session.table}</h3>
+      <div className="mb-2">
+        {session.flavors.map((f) => (
+          <FlavorBadge key={f} flavor={f} />
+        ))}
+      </div>
+      <div className="font-mono mb-2">
+        Timer: {Math.floor(elapsedMin)}:{String(elapsedSec).padStart(2, '0')}
+      </div>
+      <div className="mb-2">Status: {status.label}</div>
+      {mode === 'staff' && (
+        <div className="space-x-2">
+          <button
+            onClick={() => onRefill(session.id)}
+            className="bg-black bg-opacity-20 px-3 py-1 rounded disabled:opacity-50"
+            disabled={status.label === 'Burnt Out'}
+          >
+            Refill
+          </button>
+          <button
+            onClick={() => {
+              const note = window.prompt('Session note');
+              if (note) onAddNote(session.id, note);
+            }}
+            className="bg-black bg-opacity-20 px-3 py-1 rounded"
+          >
+            Add Note
+          </button>
+        </div>
+      )}
+      {mode !== 'staff' && <div className="mb-1">Price: ${price.toFixed(2)}</div>}
+      {mode === 'owner' && (
+        <div className="text-xs">Loyalty Signal: {session.notes?.length || 0} notes</div>
+      )}
+    </div>
+  );
+}

--- a/components/TrustLog.tsx
+++ b/components/TrustLog.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Session } from './SessionCard';
+
+interface Props {
+  sessions: Session[];
+}
+
+// Renders session notes for audit purposes; hidden from regular view
+export default function TrustLog({ sessions }: Props) {
+  return (
+    <div className="hidden" aria-hidden>
+      {sessions.map((s) => (
+        <pre key={s.id} data-table={s.table}>
+          {JSON.stringify(s.notes)}
+        </pre>
+      ))}
+    </div>
+  );
+}

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export type ViewMode = 'staff' | 'manager' | 'owner';
+
+interface Props {
+  mode: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+const modes: ViewMode[] = ['staff', 'manager', 'owner'];
+
+export default function ViewModeToggle({ mode, onChange }: Props) {
+  return (
+    <div className="mb-4 flex space-x-2">
+      {modes.map((m) => (
+        <button
+          key={m}
+          className={`px-3 py-1 rounded ${m === mode ? 'bg-ember text-white' : 'bg-gray-800 text-gray-300'}`}
+          onClick={() => onChange(m)}
+        >
+          {m.charAt(0).toUpperCase() + m.slice(1)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from 'react';
+import SessionCard, { Session } from '../components/SessionCard';
+import ViewModeToggle, { ViewMode } from '../components/ViewModeToggle';
+import TrustLog from '../components/TrustLog';
+import SessionAnalytics from '../components/SessionAnalytics';
+import OwnerMetrics from '../components/OwnerMetrics';
+
+const initialSessions: Session[] = [
+  {
+    id: 1,
+    table: 'A1',
+    flavors: ['Mint', 'Lemon'],
+    startTime: Date.now() - 5 * 60000,
+    refills: 0,
+    notes: [],
+  },
+  {
+    id: 2,
+    table: 'B2',
+    flavors: ['Grape'],
+    startTime: Date.now() - 30 * 60000,
+    refills: 0,
+    notes: [],
+  },
+];
+
+export default function Dashboard() {
+  const [mode, setMode] = useState<ViewMode>('staff');
+  const [sessions, setSessions] = useState<Session[]>(initialSessions);
+
+  const handleRefill = (id: number) => {
+    setSessions((prev) =>
+      prev.map((s) =>
+        s.id === id
+          ? {
+              ...s,
+              startTime: Date.now(),
+              refills: s.refills + 1,
+              notes: [...(s.notes || []), 'refill'],
+            }
+          : s
+      )
+    );
+  };
+
+  const handleAddNote = (id: number, note: string) => {
+    setSessions((prev) =>
+      prev.map((s) =>
+        s.id === id ? { ...s, notes: [...(s.notes || []), note] } : s
+      )
+    );
+  };
+
+  const handleBurnout = (id: number) => {
+    setSessions((prev) =>
+      prev.map((s) =>
+        s.id === id && !(s.notes || []).includes('burnout')
+          ? { ...s, notes: [...(s.notes || []), 'burnout'] }
+          : s
+      )
+    );
+  };
+
+  return (
+    <main className="p-4 bg-black min-h-screen text-white">
+      <h1 className="text-2xl font-bold mb-4">Flavor Flow Dashboard</h1>
+      <ViewModeToggle mode={mode} onChange={setMode} />
+      {sessions.map((session) => (
+        <SessionCard
+          key={session.id}
+          session={session}
+          mode={mode}
+          onRefill={handleRefill}
+          onAddNote={handleAddNote}
+          onBurnout={handleBurnout}
+        />
+      ))}
+      {mode === 'manager' && <SessionAnalytics sessions={sessions} />}
+      {mode === 'owner' && <OwnerMetrics sessions={sessions} />}
+      <TrustLog sessions={sessions} />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- track refills and burnout with quick note logging per session
- add manager analytics and owner metrics panels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d340559483309da2e063f7b2ded4