### PR TITLE
Add Hookah index configuration and dashboard widget

### DIFF
--- a/"b/codex/indices/\316\224HookahIndex_V1.yaml"
+++ b/"b/codex/indices/\316\224HookahIndex_V1.yaml"
@@ -1,0 +1,25 @@
+index_version: "ΔHookahIndex_V1"
+base_metrics:
+  - HPI
+  - STI
+  - UMI
+  - CSI
+  - VRI
+personas:
+  Sam the Social Explorer:
+    segment_pct: 35
+    STAR: >
+      Situation: New staff struggle to coach first-timers → Action: Auto-tutorial + QR session → Result: Staff time ↓ 40%, rookie retention ↑
+  Riley the Session Maximizer:
+    segment_pct: 30
+    STAR: >
+      Situation: Off-peak underutilized → Action: Time slot prompts + dynamic pricing → Result: Profits ↑ 15%, seats filled
+  Omar the Flavor Connoisseur:
+    segment_pct: 15
+    STAR: >
+      Situation: Flavor loyalists want novelty → Action: Premium curation tab + upsells → Result: Ticket value ↑ 25%, loyalty tier locked
+reflex_loop_enabled: true
+triggers:
+  - "CI/CD pipeline → auto-rollout new microcopy & flows"
+  - "Whisper Flags → feedback into STI & VRI metrics"
+  - "Agent scraping → trend sync from Reddit, TikTok, Yelp"

--- a/dashboard/widgets/Hookah+IndexPanel.tsx
+++ b/dashboard/widgets/Hookah+IndexPanel.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const indexPath = path.join(process.cwd(), 'codex/indices/ΔHookahIndex_V1.yaml');
+const raw = fs.readFileSync(indexPath, 'utf8');
+const data = yaml.load(raw) as any;
+
+export default function HookahIndexPanel() {
+  return (
+    <div className="p-4 bg-gray-900 rounded text-white mb-4">
+      <h2 className="font-bold mb-2">Hookah+ Index {data.index_version}</h2>
+      <div className="mb-2">
+        <span className="font-semibold">Base Metrics:</span>
+        <ul className="list-disc list-inside">
+          {data.base_metrics.map((m: string) => (
+            <li key={m}>{m}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="mb-2">
+        <span className="font-semibold">Personas:</span>
+        <ul className="list-disc list-inside">
+          {Object.entries(data.personas).map(([name, info]: [string, any]) => (
+            <li key={name} className="mb-1">
+              <div className="font-semibold">{name} ({info.segment_pct}%)</div>
+              <div className="text-sm">{info.STAR}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="mb-2">
+        <span className="font-semibold">Triggers:</span>
+        <ul className="list-disc list-inside">
+          {data.triggers.map((t: string) => (
+            <li key={t}>{t}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="text-sm">Reflex Loop Enabled: {data.reflex_loop_enabled ? 'Yes' : 'No'}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- configure Hookah+ trust metrics and persona STAR data via `ΔHookahIndex_V1.yaml`
- render index metrics in a new `Hookah+IndexPanel` dashboard widget

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68910e6331f88330a9c298cf58c220a7