### PR TITLE
Ensure all Next.js entry points load global styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ git submodule update --init --recursive
 
 This command fetches the `netlify` submodule and checks out the appropriate commit.
 
+## Global Styles
+
+Ensure every Next.js entry point (`pages/_app.tsx`, custom `_document.tsx`, or `app/layout.tsx`) imports `styles/globals.css`. For standalone sub-apps like `app/dashboard`, include the global import or copy the moodbook variables so styling stays consistent.
+
 ## Command Dispatcher
 Utility tasks can be run via `cmd_dispatcher.py`. Invoke it with a command name to call the corresponding helper in `cmd/modules/reflex_ui.py`:
 

--- a/app/dashboard/pages/_app.tsx
+++ b/app/dashboard/pages/_app.tsx
@@ -1,0 +1,8 @@
+import '../../../styles/globals.css';
+import type { AppProps } from 'next/app';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;


### PR DESCRIPTION
## Summary
- add `_app.tsx` for dashboard sub-app and import shared `styles/globals.css`
- document requirement that every Next.js entry point includes `globals.css`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `(cd app/dashboard && npm test)` *(fails: Missing script: "test")*
- `(cd app/dashboard && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_689119ce5df08330b48337d92945697b