### PR TITLE
refactor: swap tailwind colors with moodbook tokens

### DIFF
--- a/app/demo/WhisperButton.tsx
+++ b/app/demo/WhisperButton.tsx
@@ -7,7 +7,7 @@ export default function WhisperButton() {
         // Trigger future Aliethia whisper interface here
         alert('Aliethia Whisper Preview Activated 🎙️');
       }}
-      className="mt-4 text-cyan-400 hover:underline"
+      className="mt-4 text-ember hover:underline"
     >
       Play Whisper →
     </button>

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -5,58 +5,58 @@ import WhisperButton from './WhisperButton';
 
 export default function DemoPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-black via-zinc-900 to-neutral-800 text-white px-6 py-12">
+    <main className="min-h-screen bg-charcoal text-goldLumen px-6 py-12">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-4xl font-extrabold tracking-tight">
           🎬 Demo Preview Portal
         </h1>
         <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
-        <p className="mt-4 text-lg text-zinc-300">
+        <p className="mt-4 text-lg text-goldLumen/80">
           Explore what Hookah+ can unlock in your lounge. This preview simulates real-time session flow, flavor memory, and loyalty intelligence.
         </p>
 
         <div className="mt-10 grid gap-6 sm:grid-cols-2">
-          <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
+          <div className="rounded-xl border border-charcoal bg-charcoal p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🕹️ Live Session Simulation</h2>
-            <p className="mt-2 text-zinc-400">Preview how customers engage, order, and unlock flavor points.</p>
+            <p className="mt-2 text-goldLumen/70">Preview how customers engage, order, and unlock flavor points.</p>
             <Link
               href="/live"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
             >
               Launch Live Session →
             </Link>
           </div>
 
-          <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
+          <div className="rounded-xl border border-charcoal bg-charcoal p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🌬️ Flavor Mix Journey</h2>
-            <p className="mt-2 text-zinc-400">Explore dynamic flavor combinations and their loyalty effects.</p>
+            <p className="mt-2 text-goldLumen/70">Explore dynamic flavor combinations and their loyalty effects.</p>
             <Link
               href="/flavors"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
             >
               Try Flavor Flow →
             </Link>
           </div>
 
-          <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
+          <div className="rounded-xl border border-charcoal bg-charcoal p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">📈 Loyalty Dashboard Preview</h2>
-            <p className="mt-2 text-zinc-400">View how Hookah+ tracks, scores, and rewards session behavior.</p>
+            <p className="mt-2 text-goldLumen/70">View how Hookah+ tracks, scores, and rewards session behavior.</p>
             <Link
               href="/loyalty"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
             >
               View Loyalty Portal →
             </Link>
           </div>
 
-          <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
+          <div className="rounded-xl border border-charcoal bg-charcoal p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🧠 Alie Voice Reflex</h2>
-            <p className="mt-2 text-zinc-400">Experience a whisper from Alie guiding session flow.</p>
+            <p className="mt-2 text-goldLumen/70">Experience a whisper from Alie guiding session flow.</p>
             <WhisperButton />
           </div>
         </div>
 
-        <div className="mt-12 text-center text-zinc-400 text-sm">
+        <div className="mt-12 text-center text-goldLumen/70 text-sm">
           ⌛ Demo Layer: Reflex Preview Mode | v1.0 | EP Score: 8.7 → awaiting session lock
         </div>
       </div>

--- a/app/flavors/SelectorAphrodite.tsx
+++ b/app/flavors/SelectorAphrodite.tsx
@@ -52,13 +52,13 @@ export default function SelectorAphrodite({ flavors }: Props) {
               onClick={() => toggleFlavor(flavor.name)}
               className={`px-4 py-2 border rounded ${
                 selected.includes(flavor.name)
-                  ? 'bg-cyan-600 text-white'
-                  : 'bg-zinc-800 text-zinc-200'
+                  ? 'bg-mystic text-charcoal'
+                  : 'bg-charcoal text-goldLumen/70'
               }`}
             >
               {flavor.name}
             </button>
-            <span className="ml-2 text-sm text-zinc-400">{flavor.notes}</span>
+            <span className="ml-2 text-sm text-goldLumen/70">{flavor.notes}</span>
           </li>
         ))}
       </ul>

--- a/components/FlavorBadge.tsx
+++ b/components/FlavorBadge.tsx
@@ -14,7 +14,7 @@ const flavorEmoji: Record<string, string> = {
 
 export default function FlavorBadge({ flavor }: Props) {
   return (
-    <span className="inline-flex items-center px-2 py-1 bg-gray-800 rounded text-sm mr-1" title={flavor}>
+    <span className="inline-flex items-center px-2 py-1 bg-charcoal rounded text-sm mr-1" title={flavor}>
       <span className="mr-1">{flavorEmoji[flavor] || '🍓'}</span>
       {flavor}
     </span>

--- a/components/FlavorSelector.tsx
+++ b/components/FlavorSelector.tsx
@@ -24,7 +24,7 @@ export default function FlavorSelector({ value, onChange }: Props) {
     <div className="mb-4">
       <label className="block text-sm font-medium mb-1">Flavor</label>
       <select
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-charcoal text-goldLumen"
         value={value}
         onChange={(e) => handleChange(e.target.value)}
       >

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -15,13 +15,13 @@ export default function OnboardingModal({ onComplete }: Props) {
   const [timer, setTimer] = useState(60);
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-gray-900 p-6 rounded shadow-xl w-80">
+    <div className="fixed inset-0 flex items-center justify-center bg-charcoal/70">
+      <div className="bg-charcoal p-6 rounded shadow-xl w-80">
         <h2 className="text-xl font-bold mb-4">Set Up Session</h2>
         <FlavorSelector value={flavor} onChange={setFlavor} />
         <TimerControl value={timer} onChange={setTimer} />
         <button
-          className="mt-4 w-full bg-blue-600 hover:bg-blue-500 text-white py-2 px-4 rounded"
+          className="mt-4 w-full bg-ember hover:bg-mystic text-goldLumen py-2 px-4 rounded"
           onClick={() => {
             reflex?.logEvent('loyalty_triggered', {
               flavor,

--- a/components/OwnerMetrics.tsx
+++ b/components/OwnerMetrics.tsx
@@ -16,7 +16,7 @@ export default function OwnerMetrics({ sessions }: { sessions: Session[] }) {
   const totalRevenue = Object.values(flavorRevenue).reduce((a, b) => a + b, 0);
   const ratio = refills > 0 ? (burnouts / refills).toFixed(2) : '0';
   return (
-    <div className="p-4 bg-gray-900 rounded text-white mb-4">
+    <div className="p-4 bg-charcoal rounded text-goldLumen mb-4">
       <h2 className="font-bold mb-2">Owner Metrics</h2>
       <div className="text-sm mb-2">Total Revenue: ${totalRevenue.toFixed(2)}</div>
       {Object.entries(flavorRevenue).map(([flavor, revenue]) => (

--- a/components/ReflexCard.tsx
+++ b/components/ReflexCard.tsx
@@ -17,12 +17,12 @@ export const ReflexCard: React.FC<ReflexCardProps> = ({ title, description, cta,
       {href ? (
         <Link
           href={href}
-          className="inline-block bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded"
+          className="inline-block bg-ember hover:bg-mystic text-goldLumen mt-4 px-4 py-2 rounded"
         >
           {cta}
         </Link>
       ) : (
-        <button className="bg-ember hover:bg-mystic text-white mt-4 px-4 py-2 rounded">{cta}</button>
+        <button className="bg-ember hover:bg-mystic text-goldLumen mt-4 px-4 py-2 rounded">{cta}</button>
       )}
     </div>
   );

--- a/components/SessionAnalytics.tsx
+++ b/components/SessionAnalytics.tsx
@@ -18,7 +18,7 @@ export default function SessionAnalytics({ sessions }: { sessions: Session[] }) 
   const avgRefills =
     sessions.reduce((sum, s) => sum + (s.refills || 0), 0) / sessions.length;
   return (
-    <div className="p-4 bg-gray-900 rounded text-white mb-4">
+    <div className="p-4 bg-charcoal rounded text-goldLumen mb-4">
       <h2 className="font-bold mb-2">Manager Analytics</h2>
       <div className="text-sm mb-2">
         Avg Refills/Session: {avgRefills.toFixed(1)}

--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -47,7 +47,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
   const price = session.flavors.length * 15 + session.refills * 5;
 
   return (
-    <div className={`p-4 rounded-xl text-white mb-4 ${status.tone}`}>
+    <div className={`p-4 rounded-xl text-goldLumen mb-4 ${status.tone}`}>
       <h3 className="font-bold text-lg mb-1">Table {session.table}</h3>
       <div className="mb-2">
         {session.flavors.map((f) => (
@@ -62,7 +62,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
         <div className="space-x-2">
           <button
             onClick={() => onRefill(session.id)}
-            className="bg-black bg-opacity-20 px-3 py-1 rounded disabled:opacity-50"
+            className="bg-charcoal/20 px-3 py-1 rounded disabled:opacity-50"
             disabled={status.label === 'Burnt Out'}
           >
             Refill
@@ -72,7 +72,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
               const note = window.prompt('Session note');
               if (note) onAddNote(session.id, note);
             }}
-            className="bg-black bg-opacity-20 px-3 py-1 rounded"
+            className="bg-charcoal/20 px-3 py-1 rounded"
           >
             Add Note
           </button>

--- a/components/TimerControl.tsx
+++ b/components/TimerControl.tsx
@@ -12,7 +12,7 @@ export default function TimerControl({ value, onChange }: Props) {
       <input
         type="number"
         min="0"
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-charcoal text-goldLumen"
         value={value}
         onChange={(e) => onChange(parseInt(e.target.value, 10))}
       />

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -15,7 +15,7 @@ export default function ViewModeToggle({ mode, onChange }: Props) {
       {modes.map((m) => (
         <button
           key={m}
-          className={`px-3 py-1 rounded ${m === mode ? 'bg-ember text-white' : 'bg-gray-800 text-gray-300'}`}
+          className={`px-3 py-1 rounded ${m === mode ? 'bg-ember text-goldLumen' : 'bg-charcoal text-goldLumen/70'}`}
           onClick={() => onChange(m)}
         >
           {m.charAt(0).toUpperCase() + m.slice(1)}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -64,7 +64,7 @@ export default function Dashboard() {
   };
 
   return (
-    <main className="p-4 bg-black min-h-screen text-white">
+    <main className="p-4 bg-charcoal min-h-screen text-goldLumen">
       <h1 className="text-2xl font-bold mb-4">Flavor Flow Dashboard</h1>
       <ViewModeToggle mode={mode} onChange={setMode} />
       {sessions.map((session) => (

--- a/pages/live-session.tsx
+++ b/pages/live-session.tsx
@@ -1,6 +1,6 @@
 export default function LiveSession() {
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white">
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-charcoal text-goldLumen">
       <h1 className="text-3xl font-bold mb-4">Join Live Session</h1>
       <p>Connect in real-time with Hookah+ support.</p>
     </main>

--- a/pages/onboarding.tsx
+++ b/pages/onboarding.tsx
@@ -12,7 +12,7 @@ export default function Onboarding() {
   }, []);
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white">
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-charcoal text-goldLumen">
       <h1 className="text-3xl font-bold mb-4">Lounge Onboarding</h1>
       <p>Start configuring your lounge with Hookah+.</p>
       {showModal && <OnboardingModal onComplete={() => setShowModal(false)} />}


### PR DESCRIPTION
## Summary
- replace Tailwind grays/black/white with moodbook colors across components
- use moodbook tokens for demo and flavor selector accents
- clean up remaining default color classes

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689119c6404083308ffd6a5fff5741e7