### PR TITLE
Apply moodbook font utilities

### DIFF
--- a/app/demo/WhisperButton.tsx
+++ b/app/demo/WhisperButton.tsx
@@ -7,7 +7,7 @@ export default function WhisperButton() {
         // Trigger future Aliethia whisper interface here
         alert('Aliethia Whisper Preview Activated 🎙️');
       }}
-      className="mt-4 text-cyan-400 hover:underline"
+      className="mt-4 text-cyan-400 hover:underline font-sans"
     >
       Play Whisper →
     </button>

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -5,58 +5,58 @@ import WhisperButton from './WhisperButton';
 
 export default function DemoPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-black via-zinc-900 to-neutral-800 text-white px-6 py-12">
+    <main className="min-h-screen bg-gradient-to-br from-black via-zinc-900 to-neutral-800 text-white px-6 py-12 font-sans">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-extrabold tracking-tight">
+        <h1 className="text-4xl font-display font-extrabold tracking-tight">
           🎬 Demo Preview Portal
         </h1>
         <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
-        <p className="mt-4 text-lg text-zinc-300">
+        <p className="mt-4 text-lg text-zinc-300 font-sans">
           Explore what Hookah+ can unlock in your lounge. This preview simulates real-time session flow, flavor memory, and loyalty intelligence.
         </p>
 
         <div className="mt-10 grid gap-6 sm:grid-cols-2">
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">🕹️ Live Session Simulation</h2>
-            <p className="mt-2 text-zinc-400">Preview how customers engage, order, and unlock flavor points.</p>
+            <h2 className="text-xl font-display font-semibold">🕹️ Live Session Simulation</h2>
+            <p className="mt-2 text-zinc-400 font-sans">Preview how customers engage, order, and unlock flavor points.</p>
             <Link
               href="/live"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1] font-sans"
             >
               Launch Live Session →
             </Link>
           </div>
 
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">🌬️ Flavor Mix Journey</h2>
-            <p className="mt-2 text-zinc-400">Explore dynamic flavor combinations and their loyalty effects.</p>
+            <h2 className="text-xl font-display font-semibold">🌬️ Flavor Mix Journey</h2>
+            <p className="mt-2 text-zinc-400 font-sans">Explore dynamic flavor combinations and their loyalty effects.</p>
             <Link
               href="/flavors"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1] font-sans"
             >
               Try Flavor Flow →
             </Link>
           </div>
 
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">📈 Loyalty Dashboard Preview</h2>
-            <p className="mt-2 text-zinc-400">View how Hookah+ tracks, scores, and rewards session behavior.</p>
+            <h2 className="text-xl font-display font-semibold">📈 Loyalty Dashboard Preview</h2>
+            <p className="mt-2 text-zinc-400 font-sans">View how Hookah+ tracks, scores, and rewards session behavior.</p>
             <Link
               href="/loyalty"
-              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              className="mt-4 inline-block text-cyan-400 transition-shadow hover:shadow-[0_0_8px_#E8D7B1] font-sans"
             >
               View Loyalty Portal →
             </Link>
           </div>
 
           <div className="rounded-xl border border-zinc-700 bg-zinc-800 p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">🧠 Alie Voice Reflex</h2>
-            <p className="mt-2 text-zinc-400">Experience a whisper from Alie guiding session flow.</p>
+            <h2 className="text-xl font-display font-semibold">🧠 Alie Voice Reflex</h2>
+            <p className="mt-2 text-zinc-400 font-sans">Experience a whisper from Alie guiding session flow.</p>
             <WhisperButton />
           </div>
         </div>
 
-        <div className="mt-12 text-center text-zinc-400 text-sm">
+        <div className="mt-12 text-center text-zinc-400 text-sm font-sans">
           ⌛ Demo Layer: Reflex Preview Mode | v1.0 | EP Score: 8.7 → awaiting session lock
         </div>
       </div>

--- a/app/flavors/SelectorAphrodite.tsx
+++ b/app/flavors/SelectorAphrodite.tsx
@@ -44,13 +44,13 @@ export default function SelectorAphrodite({ flavors }: Props) {
 
 
   return (
-    <div className="mt-4">
+    <div className="mt-4 font-sans">
       <ul className="space-y-2">
         {flavors.map((flavor) => (
           <li key={flavor.name}>
             <button
               onClick={() => toggleFlavor(flavor.name)}
-              className={`px-4 py-2 border rounded ${
+              className={`px-4 py-2 border rounded font-sans ${
                 selected.includes(flavor.name)
                   ? 'bg-cyan-600 text-white'
                   : 'bg-zinc-800 text-zinc-200'
@@ -65,7 +65,7 @@ export default function SelectorAphrodite({ flavors }: Props) {
 
       {selected.length > 0 && (
         <div className="mt-6 space-y-4">
-          <p className="text-mystic">Your loyalty flavor has been saved.</p>
+          <p className="text-mystic font-sans">Your loyalty flavor has been saved.</p>
         </div>
       )}
     </div>

--- a/app/flavors/page.tsx
+++ b/app/flavors/page.tsx
@@ -9,8 +9,8 @@ export default function FlavorsPage() {
   const flavors = yaml.load(fileContents) as { name: string; notes: string }[];
 
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold">Flavor Selector</h1>
+    <div className="p-8 font-sans">
+      <h1 className="text-2xl font-display font-bold">Flavor Selector</h1>
       <SelectorAphrodite flavors={flavors} />
     </div>
   );

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,8 +1,8 @@
 export default function LivePage() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold">Live Session</h1>
-      <p className="mt-2">Live session interface coming soon.</p>
+    <main className="p-8 font-sans">
+      <h1 className="text-2xl font-display font-bold">Live Session</h1>
+      <p className="mt-2 font-sans">Live session interface coming soon.</p>
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,9 +25,9 @@ export default function Home() {
   ];
 
   return (
-    <main className="p-8 flex flex-col items-center space-y-8">
+    <main className="p-8 flex flex-col items-center space-y-8 font-sans">
       <h1 className="text-3xl font-display">Welcome to Hookah+</h1>
-      <p className="mt-2 text-center max-w-xl">
+      <p className="mt-2 text-center max-w-xl font-sans">
         Your command center for flavor, flow, and loyalty intelligence.
       </p>
       <div className="grid gap-6 md:grid-cols-3">

--- a/components/DynamicPricing.jsx
+++ b/components/DynamicPricing.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 const DynamicPricing = ({ basePrice, addOns }) => {
   const total = basePrice + addOns.reduce((sum, item) => sum + item.price, 0);
   return (
-    <div>
-      <h2>Session Price: ${total}</h2>
+    <div className="font-sans">
+      <h2 className="font-display">Session Price: ${total}</h2>
       <ul>
         {addOns.map((item, index) => (
           <li key={index}>{item.name}: ${item.price}</li>

--- a/components/FlavorBadge.tsx
+++ b/components/FlavorBadge.tsx
@@ -14,7 +14,10 @@ const flavorEmoji: Record<string, string> = {
 
 export default function FlavorBadge({ flavor }: Props) {
   return (
-    <span className="inline-flex items-center px-2 py-1 bg-gray-800 rounded text-sm mr-1" title={flavor}>
+    <span
+      className="font-sans inline-flex items-center px-2 py-1 bg-gray-800 rounded text-sm mr-1"
+      title={flavor}
+    >
       <span className="mr-1">{flavorEmoji[flavor] || '🍓'}</span>
       {flavor}
     </span>

--- a/components/FlavorSelector.jsx
+++ b/components/FlavorSelector.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 const FlavorSelector = ({ flavors, onSelect }) => (
-  <div>
-    <h2>Select Your Flavor</h2>
+  <div className="font-sans">
+    <h2 className="font-display">Select Your Flavor</h2>
     <ul>
       {flavors.map((flavor, index) => (
-        <li key={index} onClick={() => onSelect(flavor)}>{flavor}</li>
+        <li key={index} onClick={() => onSelect(flavor)}>
+          {flavor}
+        </li>
       ))}
     </ul>
   </div>

--- a/components/FlavorSelector.tsx
+++ b/components/FlavorSelector.tsx
@@ -21,10 +21,10 @@ export default function FlavorSelector({ value, onChange }: Props) {
   };
 
   return (
-    <div className="mb-4">
+    <div className="mb-4 font-sans">
       <label className="block text-sm font-medium mb-1">Flavor</label>
       <select
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-gray-800 text-white font-sans"
         value={value}
         onChange={(e) => handleChange(e.target.value)}
       >

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -16,8 +16,8 @@ export default function OnboardingModal({ onComplete }: Props) {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-gray-900 p-6 rounded shadow-xl w-80">
-        <h2 className="text-xl font-bold mb-4">Set Up Session</h2>
+      <div className="bg-gray-900 p-6 rounded shadow-xl w-80 font-sans">
+        <h2 className="text-xl font-display font-bold mb-4">Set Up Session</h2>
         <FlavorSelector value={flavor} onChange={setFlavor} />
         <TimerControl value={timer} onChange={setTimer} />
         <button

--- a/components/OwnerMetrics.tsx
+++ b/components/OwnerMetrics.tsx
@@ -16,8 +16,8 @@ export default function OwnerMetrics({ sessions }: { sessions: Session[] }) {
   const totalRevenue = Object.values(flavorRevenue).reduce((a, b) => a + b, 0);
   const ratio = refills > 0 ? (burnouts / refills).toFixed(2) : '0';
   return (
-    <div className="p-4 bg-gray-900 rounded text-white mb-4">
-      <h2 className="font-bold mb-2">Owner Metrics</h2>
+    <div className="p-4 bg-gray-900 rounded text-white mb-4 font-sans">
+      <h2 className="font-display font-bold mb-2">Owner Metrics</h2>
       <div className="text-sm mb-2">Total Revenue: ${totalRevenue.toFixed(2)}</div>
       {Object.entries(flavorRevenue).map(([flavor, revenue]) => (
         <div key={flavor} className="text-sm">

--- a/components/SessionAnalytics.tsx
+++ b/components/SessionAnalytics.tsx
@@ -18,8 +18,8 @@ export default function SessionAnalytics({ sessions }: { sessions: Session[] }) 
   const avgRefills =
     sessions.reduce((sum, s) => sum + (s.refills || 0), 0) / sessions.length;
   return (
-    <div className="p-4 bg-gray-900 rounded text-white mb-4">
-      <h2 className="font-bold mb-2">Manager Analytics</h2>
+    <div className="p-4 bg-gray-900 rounded text-white mb-4 font-sans">
+      <h2 className="font-display font-bold mb-2">Manager Analytics</h2>
       <div className="text-sm mb-2">
         Avg Refills/Session: {avgRefills.toFixed(1)}
       </div>

--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -47,8 +47,8 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
   const price = session.flavors.length * 15 + session.refills * 5;
 
   return (
-    <div className={`p-4 rounded-xl text-white mb-4 ${status.tone}`}>
-      <h3 className="font-bold text-lg mb-1">Table {session.table}</h3>
+    <div className={`p-4 rounded-xl text-white mb-4 ${status.tone} font-sans`}>
+      <h3 className="font-display font-bold text-lg mb-1">Table {session.table}</h3>
       <div className="mb-2">
         {session.flavors.map((f) => (
           <FlavorBadge key={f} flavor={f} />

--- a/components/SessionTimer.jsx
+++ b/components/SessionTimer.jsx
@@ -3,10 +3,14 @@ import React, { useState, useEffect } from 'react';
 const SessionTimer = () => {
   const [seconds, setSeconds] = useState(0);
   useEffect(() => {
-    const timer = setInterval(() => setSeconds(prev => prev + 1), 1000);
+    const timer = setInterval(() => setSeconds((prev) => prev + 1), 1000);
     return () => clearInterval(timer);
   }, []);
-  return <h2>Session Time: {Math.floor(seconds / 60)} min {seconds % 60} sec</h2>;
+  return (
+    <h2 className="font-display">
+      Session Time: {Math.floor(seconds / 60)} min {seconds % 60} sec
+    </h2>
+  );
 };
 
 export default SessionTimer;

--- a/components/TimerControl.tsx
+++ b/components/TimerControl.tsx
@@ -7,12 +7,12 @@ interface Props {
 
 export default function TimerControl({ value, onChange }: Props) {
   return (
-    <div className="mb-4">
+    <div className="mb-4 font-sans">
       <label className="block text-sm font-medium mb-1">Session Timer (min)</label>
       <input
         type="number"
         min="0"
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-gray-800 text-white font-sans"
         value={value}
         onChange={(e) => onChange(parseInt(e.target.value, 10))}
       />

--- a/components/TrustLog.tsx
+++ b/components/TrustLog.tsx
@@ -8,9 +8,9 @@ interface Props {
 // Renders session notes for audit purposes; hidden from regular view
 export default function TrustLog({ sessions }: Props) {
   return (
-    <div className="hidden" aria-hidden>
+    <div className="hidden font-sans" aria-hidden>
       {sessions.map((s) => (
-        <pre key={s.id} data-table={s.table}>
+        <pre key={s.id} data-table={s.table} className="font-mono">
           {JSON.stringify(s.notes)}
         </pre>
       ))}

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -11,11 +11,13 @@ const modes: ViewMode[] = ['staff', 'manager', 'owner'];
 
 export default function ViewModeToggle({ mode, onChange }: Props) {
   return (
-    <div className="mb-4 flex space-x-2">
+    <div className="mb-4 flex space-x-2 font-sans">
       {modes.map((m) => (
         <button
           key={m}
-          className={`px-3 py-1 rounded ${m === mode ? 'bg-ember text-white' : 'bg-gray-800 text-gray-300'}`}
+          className={`px-3 py-1 rounded font-sans ${
+            m === mode ? 'bg-ember text-white' : 'bg-gray-800 text-gray-300'
+          }`}
           onClick={() => onChange(m)}
         >
           {m.charAt(0).toUpperCase() + m.slice(1)}

--- a/components/WhisperTrigger.tsx
+++ b/components/WhisperTrigger.tsx
@@ -6,7 +6,7 @@ export default function WhisperTrigger() {
       onClick={() => {
         alert('Alie intro whisper pending.');
       }}
-      className="mt-8 px-6 py-3 bg-mystic text-charcoal rounded-full animate-pulse hover:animate-none transition transform hover:scale-105"
+      className="mt-8 px-6 py-3 bg-mystic text-charcoal rounded-full animate-pulse hover:animate-none transition transform hover:scale-105 font-sans"
     >
       Play Alie’s Intro
     </button>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -64,8 +64,8 @@ export default function Dashboard() {
   };
 
   return (
-    <main className="p-4 bg-black min-h-screen text-white">
-      <h1 className="text-2xl font-bold mb-4">Flavor Flow Dashboard</h1>
+    <main className="p-4 bg-black min-h-screen text-white font-sans">
+      <h1 className="text-2xl font-display font-bold mb-4">Flavor Flow Dashboard</h1>
       <ViewModeToggle mode={mode} onChange={setMode} />
       {sessions.map((session) => (
         <SessionCard

--- a/pages/live-session.tsx
+++ b/pages/live-session.tsx
@@ -1,8 +1,8 @@
 export default function LiveSession() {
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white">
-      <h1 className="text-3xl font-bold mb-4">Join Live Session</h1>
-      <p>Connect in real-time with Hookah+ support.</p>
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white font-sans">
+      <h1 className="text-3xl font-display font-bold mb-4">Join Live Session</h1>
+      <p className="font-sans">Connect in real-time with Hookah+ support.</p>
     </main>
   );
 }

--- a/pages/onboarding.tsx
+++ b/pages/onboarding.tsx
@@ -12,9 +12,9 @@ export default function Onboarding() {
   }, []);
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white">
-      <h1 className="text-3xl font-bold mb-4">Lounge Onboarding</h1>
-      <p>Start configuring your lounge with Hookah+.</p>
+    <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-black text-white font-sans">
+      <h1 className="text-3xl font-display font-bold mb-4">Lounge Onboarding</h1>
+      <p className="font-sans">Start configuring your lounge with Hookah+.</p>
       {showModal && <OnboardingModal onComplete={() => setShowModal(false)} />}
     </main>
   );


### PR DESCRIPTION
## Summary
- ensure moodbook font stack is applied across components and pages
- use `font-display` for headings and `font-sans` for body content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689119c43f148330b0eb430ff0131f29