### PR TITLE
Use moodbook theme in shared components

### DIFF
--- a/components/FlavorBadge.tsx
+++ b/components/FlavorBadge.tsx
@@ -12,9 +12,13 @@ const flavorEmoji: Record<string, string> = {
   Grape: '🍇',
 };
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 export default function FlavorBadge({ flavor }: Props) {
   return (
-    <span className="inline-flex items-center px-2 py-1 bg-gray-800 rounded text-sm mr-1" title={flavor}>
+    <span
+      className="inline-flex items-center rounded bg-deepMoss px-2 py-1 text-goldLumen text-sm mr-1"
+      title={flavor}
+    >
       <span className="mr-1">{flavorEmoji[flavor] || '🍓'}</span>
       {flavor}
     </span>

--- a/components/FlavorSelector.jsx
+++ b/components/FlavorSelector.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 const FlavorSelector = ({ flavors, onSelect }) => (
-  <div>
+  <div className="rounded bg-charcoal p-4 text-goldLumen">
     <h2>Select Your Flavor</h2>
     <ul>
       {flavors.map((flavor, index) => (

--- a/components/FlavorSelector.tsx
+++ b/components/FlavorSelector.tsx
@@ -9,6 +9,7 @@ interface Props {
   onChange: (value: string) => void;
 }
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 export default function FlavorSelector({ value, onChange }: Props) {
   const flavors = ['Mint', 'Double Apple', 'Grape'];
 
@@ -21,10 +22,10 @@ export default function FlavorSelector({ value, onChange }: Props) {
   };
 
   return (
-    <div className="mb-4">
+    <div className="mb-4 rounded bg-charcoal p-2 text-goldLumen">
       <label className="block text-sm font-medium mb-1">Flavor</label>
       <select
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-deepMoss text-goldLumen"
         value={value}
         onChange={(e) => handleChange(e.target.value)}
       >

--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -20,11 +20,12 @@ interface Props {
   onBurnout: (id: number) => void;
 }
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 function getStatus(elapsed: number) {
-  if (elapsed >= 70) return { label: 'Burnt Out', tone: 'bg-red-700' };
-  if (elapsed >= 45) return { label: 'Shisha Low', tone: 'bg-orange-600' };
-  if (elapsed >= 25) return { label: 'Coal Low', tone: 'bg-yellow-600' };
-  return { label: 'Active', tone: 'bg-green-700' };
+  if (elapsed >= 70) return { label: 'Burnt Out', tone: 'bg-ember' };
+  if (elapsed >= 45) return { label: 'Shisha Low', tone: 'bg-mystic' };
+  if (elapsed >= 25) return { label: 'Coal Low', tone: 'bg-deepMoss' };
+  return { label: 'Active', tone: 'bg-charcoal' };
 }
 
 export default function SessionCard({ session, mode, onRefill, onAddNote, onBurnout }: Props) {
@@ -47,7 +48,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
   const price = session.flavors.length * 15 + session.refills * 5;
 
   return (
-    <div className={`p-4 rounded-xl text-white mb-4 ${status.tone}`}>
+    <div className={`p-4 rounded-xl mb-4 bg-charcoal text-goldLumen ${status.tone}`}>
       <h3 className="font-bold text-lg mb-1">Table {session.table}</h3>
       <div className="mb-2">
         {session.flavors.map((f) => (
@@ -62,7 +63,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
         <div className="space-x-2">
           <button
             onClick={() => onRefill(session.id)}
-            className="bg-black bg-opacity-20 px-3 py-1 rounded disabled:opacity-50"
+            className="bg-charcoal/20 px-3 py-1 rounded disabled:opacity-50"
             disabled={status.label === 'Burnt Out'}
           >
             Refill
@@ -72,7 +73,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
               const note = window.prompt('Session note');
               if (note) onAddNote(session.id, note);
             }}
-            className="bg-black bg-opacity-20 px-3 py-1 rounded"
+            className="bg-charcoal/20 px-3 py-1 rounded"
           >
             Add Note
           </button>

--- a/components/TimerControl.tsx
+++ b/components/TimerControl.tsx
@@ -5,14 +5,15 @@ interface Props {
   onChange: (value: number) => void;
 }
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 export default function TimerControl({ value, onChange }: Props) {
   return (
-    <div className="mb-4">
+    <div className="mb-4 rounded bg-charcoal p-2 text-goldLumen">
       <label className="block text-sm font-medium mb-1">Session Timer (min)</label>
       <input
         type="number"
         min="0"
-        className="w-full p-2 bg-gray-800 text-white"
+        className="w-full p-2 bg-deepMoss text-goldLumen"
         value={value}
         onChange={(e) => onChange(parseInt(e.target.value, 10))}
       />

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -9,13 +9,16 @@ interface Props {
 
 const modes: ViewMode[] = ['staff', 'manager', 'owner'];
 
+// Moodbook classes are required; avoid overriding with default Tailwind colors.
 export default function ViewModeToggle({ mode, onChange }: Props) {
   return (
-    <div className="mb-4 flex space-x-2">
+    <div className="mb-4 flex space-x-2 rounded bg-charcoal p-2 text-goldLumen">
       {modes.map((m) => (
         <button
           key={m}
-          className={`px-3 py-1 rounded ${m === mode ? 'bg-ember text-white' : 'bg-gray-800 text-gray-300'}`}
+          className={`rounded px-3 py-1 ${
+            m === mode ? 'bg-ember text-charcoal' : 'bg-deepMoss text-goldLumen'
+          }`}
           onClick={() => onChange(m)}
         >
           {m.charAt(0).toUpperCase() + m.slice(1)}


### PR DESCRIPTION
## Summary
- enforce moodbook palette and document requirement in reusable components
- switch SessionCard status and controls to moodbook colors
- apply moodbook background/text classes to TimerControl and FlavorSelector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689119bf710083309bd12b4bd376214f