### PR TITLE
docs: log Flavor Flow dashboard after state

### DIFF
--- a/FlavorFlow_After_Vision.codex.md
+++ b/FlavorFlow_After_Vision.codex.md
@@ -1,0 +1,93 @@
+# ΔFlavorFlow_After_Vision.v1
+
+*Classification: Trust-Aspirational, UI/UX Canon*
+
+---
+
+## Reflexive Flavor Flow Dashboard — The Standard of Hookah+ Lounge Excellence
+
+### North Star Intent
+
+To anchor the "After" UI/UX as the **definitive operational benchmark** for Hookah+ Lounge Owners. This is no longer a preview — it's the **expected experience**. The **log**, **visual richness**, and **reflexive overlay feedback** drive clarity, action, and customer satisfaction. This *moodbook-infused layer* isn't just UI polish — it's **revenue-mapped precision**.
+
+---
+
+### Core Logic – Flavored Flow Dashboard (After Standard)
+
+#### Dashboard View Includes:
+
+* 🖼️ HookahPlus logo at top left (sticky on scroll)
+* 🧑‍🍳 Toggle: `Staff | Manager | Owner` (reflexive privileges control UI scope)
+* 📸 Lounge Layout Snapshot (visual preview from YAML + uploaded photo)
+* 🍍 Active Tables Rendered in Cards:
+  * **Table ID (e.g. A1)**
+  * **Flavor Mix (emoji-enhanced)**
+  * **Timer (live)**
+  * **Status: Heat, Flavor, Session Mood**
+  * **Customer Notes (hover reveals feedback via tooltip or expand modal)**
+  * 🔄 Refill Button (color pulses if due)
+  * 📝 Add Note (Reflex Whisper can auto-suggest input)
+
+#### 🪞 Moodbook Logic Embedded:
+
+* **Color Gradients** shift by session length & feedback signal.
+* **Shadow Depth & Glow** increase with trust indicators (e.g., "Happy Repeat Customer")
+* **Flame Pulse**: Visual marker that a session is about to expire or needs attention.
+
+#### 🌀 Reflexive Loop Triggers:
+
+* ⏱️ Timer-based prompts
+* 📥 Whisper-suggested refills or mood shifts
+* 📊 Agent-generated "Session Drift" alerts (e.g., Timer >45 mins with no refill)
+* 💬 Patron Insight Count: Live count per table (3 minimum expected per session)
+
+#### 📦 Reflex Log Snapshot:
+
+```
+🗓️ Session: 35:12 min (B2)
+💬 Insight #1: “Coal started to fade at 30 mins”
+💬 Insight #2: “Love the grape flavor, very smooth”
+💬 Insight #3: “Staff checked in right on time”
+🧠 Reflex Summary: Positive. Auto-logged to Loyalty Profile.
+```
+
+---
+
+### Lounge Owner Onboarding Logic
+
+#### One-Click Onboarding (via YAML + Image)
+
+* 📁 Upload Lounge Image
+* 📄 Upload/Drop YAML of Table Layout
+* 🔁 Auto-map tables to visual layout (via Visual Grounder)
+* ✅ Instant Preview for placement accuracy
+* 🧠 Reflex Setup Initialized:
+  * Layout + Table Memory
+  * Default pricing rules
+  * Staff/Manager roles seeded
+
+---
+
+### Why This is Hot
+
+* Owners SEE their data and tables *come alive*
+* Staff gets nudged BEFORE customers complain
+* Customers feel *seen*, *heard*, and *understood*
+* It feels like luxury. But it **saves time** and **makes money**
+* This is **hospitality gamified with integrity**
+
+---
+
+### Codex Embed Instruction
+
+> Mark this After State as the new **default and aspirational baseline** for all Lounge Dashboards.
+> Reflex Agents must treat this layout as the **trust-aligned benchmark** for simulation, feedback loops, Whisper Journals, and future Reflex Tiers.
+
+---
+
+### ✅ Codex Ref ID: `ΔFlavorFlow_After_Vision.v1`
+
+🪪 Status: **Locked**
+🔁 Agent Priority: High
+📤 Available for: `hookahplus.net/dashboard`, `Codex Store`, Agent Briefings
+


### PR DESCRIPTION
## Summary
- log Codex entry for the Flavor Flow Dashboard "After" state as the aspirational baseline for lounge dashboards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689135cd3fac83308100cc7b6f12ebda