### PR TITLE
feat: enhance dashboard layout

### DIFF
--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -22,10 +22,10 @@ interface Props {
 
 // Moodbook classes are required; avoid overriding with default Tailwind colors.
 function getStatus(elapsed: number) {
-  if (elapsed >= 70) return { label: 'Burnt Out', tone: 'bg-ember' };
-  if (elapsed >= 45) return { label: 'Shisha Low', tone: 'bg-mystic' };
-  if (elapsed >= 25) return { label: 'Coal Low', tone: 'bg-charcoal' };
-  return { label: 'Active', tone: 'bg-deepMoss' };
+  if (elapsed >= 70) return { label: 'Burnt Out', tone: 'ring-ember' };
+  if (elapsed >= 45) return { label: 'Shisha Low', tone: 'ring-mystic' };
+  if (elapsed >= 25) return { label: 'Coal Low', tone: 'ring-charcoal' };
+  return { label: 'Active', tone: 'ring-deepMoss' };
 }
 
 export default function SessionCard({ session, mode, onRefill, onAddNote, onBurnout }: Props) {
@@ -49,7 +49,9 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
   const price = session.flavors.length * 15 + session.refills * 5;
 
   return (
-    <div className={`p-4 rounded-xl mb-4 bg-charcoal text-goldLumen font-sans ${status.tone}`}>
+    <div
+      className={`flex flex-col justify-between p-4 rounded-xl bg-charcoal/30 text-goldLumen font-sans ring-2 ${status.tone} shadow-lg mb-4 md:mb-0 transition-colors duration-300 hover:bg-charcoal/40`}
+    >
       <h3 className="font-display font-bold text-lg mb-1">Table {session.table}</h3>
       <div className="mb-2">
         {session.flavors.map((f) => (
@@ -64,7 +66,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
         <div className="space-x-2">
           <button
             onClick={() => onRefill(session.id)}
-            className="bg-charcoal/20 px-3 py-1 rounded disabled:opacity-50"
+            className="bg-deepMoss/40 px-3 py-1 rounded disabled:opacity-50 hover:bg-deepMoss/60 transition-colors"
             disabled={status.label === 'Burnt Out'}
           >
             Refill
@@ -74,7 +76,7 @@ export default function SessionCard({ session, mode, onRefill, onAddNote, onBurn
               const note = window.prompt('Session note');
               if (note) onAddNote(session.id, note);
             }}
-            className="bg-charcoal/20 px-3 py-1 rounded"
+            className="bg-deepMoss/40 px-3 py-1 rounded hover:bg-deepMoss/60 transition-colors"
           >
             Add Note
           </button>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -64,22 +64,38 @@ export default function Dashboard() {
   };
 
   return (
-    <main className="p-4 bg-charcoal min-h-screen text-goldLumen font-sans">
-      <h1 className="text-2xl font-display font-bold mb-4 text-ember">Flavor Flow Dashboard</h1>
-      <ViewModeToggle mode={mode} onChange={setMode} />
-      {sessions.map((session) => (
-        <SessionCard
-          key={session.id}
-          session={session}
-          mode={mode}
-          onRefill={handleRefill}
-          onAddNote={handleAddNote}
-          onBurnout={handleBurnout}
-        />
-      ))}
-      {mode === 'manager' && <SessionAnalytics sessions={sessions} />}
-      {mode === 'owner' && <OwnerMetrics sessions={sessions} />}
-      <TrustLog sessions={sessions} />
+    <main className="min-h-screen bg-gradient-to-br from-charcoal via-deepMoss to-charcoal text-goldLumen font-sans p-6">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-3xl font-display font-bold mb-6 text-ember text-center">
+          Flavor Flow Dashboard
+        </h1>
+        <ViewModeToggle mode={mode} onChange={setMode} />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {sessions.map((session) => (
+            <SessionCard
+              key={session.id}
+              session={session}
+              mode={mode}
+              onRefill={handleRefill}
+              onAddNote={handleAddNote}
+              onBurnout={handleBurnout}
+            />
+          ))}
+        </div>
+        {mode === 'manager' && (
+          <div className="mt-8">
+            <SessionAnalytics sessions={sessions} />
+          </div>
+        )}
+        {mode === 'owner' && (
+          <div className="mt-8">
+            <OwnerMetrics sessions={sessions} />
+          </div>
+        )}
+        <div className="mt-8">
+          <TrustLog sessions={sessions} />
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- revamp dashboard page with gradient background and responsive grid
- add ring-based status styling and improved session card actions

## Testing
- `npm test`
- `npm run check:palette -- pages/dashboard.tsx components/SessionCard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689138b8a7e88330a3976bd020f46c4f