### PR TITLE
Style Hookah index panel with moodbook accents

### DIFF
--- a/dashboard/widgets/Hookah+IndexPanel.tsx
+++ b/dashboard/widgets/Hookah+IndexPanel.tsx
@@ -9,19 +9,19 @@ const data = yaml.load(raw) as any;
 
 export default function HookahIndexPanel() {
   return (
-    <div className="p-4 bg-gray-900 rounded text-white mb-4">
-      <h2 className="font-bold mb-2">Hookah+ Index {data.index_version}</h2>
+    <div className="p-4 bg-charcoal rounded text-goldLumen mb-4">
+      <h2 className="font-bold mb-2 text-ember">Hookah+ Index {data.index_version}</h2>
       <div className="mb-2">
-        <span className="font-semibold">Base Metrics:</span>
-        <ul className="list-disc list-inside">
+        <span className="font-semibold text-mystic">Base Metrics:</span>
+        <ul className="list-disc list-inside marker:text-mystic">
           {data.base_metrics.map((m: string) => (
             <li key={m}>{m}</li>
           ))}
         </ul>
       </div>
       <div className="mb-2">
-        <span className="font-semibold">Personas:</span>
-        <ul className="list-disc list-inside">
+        <span className="font-semibold text-ember">Personas:</span>
+        <ul className="list-disc list-inside marker:text-ember">
           {Object.entries(data.personas).map(([name, info]: [string, any]) => (
             <li key={name} className="mb-1">
               <div className="font-semibold">{name} ({info.segment_pct}%)</div>
@@ -31,8 +31,8 @@ export default function HookahIndexPanel() {
         </ul>
       </div>
       <div className="mb-2">
-        <span className="font-semibold">Triggers:</span>
-        <ul className="list-disc list-inside">
+        <span className="font-semibold text-mystic">Triggers:</span>
+        <ul className="list-disc list-inside marker:text-mystic">
           {data.triggers.map((t: string) => (
             <li key={t}>{t}</li>
           ))}


### PR DESCRIPTION
## Summary
- Apply Moodbook theme colors to Hookah+ Index panel background and text
- Highlight section headings and list markers with ember and mystic accents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689119acc2f88330a4578280b04aa06b