### PR TITLE
Refresh demo UI, home navigation, and codex map

### DIFF
--- a/CodexModuleMap.json
+++ b/CodexModuleMap.json
@@ -3,66 +3,76 @@
     "path": "cmd/modules/deployHomepageInteractive.py",
     "description": "Injects a Next.js homepage with links for onboarding, demo, and live sessions."
   },
-  "cmd.fireSession": {
-    "description": "Trigger a new Hookah+ session (start timer, log metadata, attach flavor config).",
-    "path": "cmd/modules/fireSession.cmd.js",
-    "tags": ["session", "launch", "core"]
-  },
-  "cmd.deployDashboard": {
-    "description": "Deploy the Hookah+ dashboard UI via Netlify using the existing token and config.",
-    "path": "cmd/modules/deployDashboard.cmd.js",
-    "tags": ["deploy", "netlify", "dashboard"]
-  },
-  "cmd.capturePOSWaitlist": {
-    "description": "Capture email and metadata of lounge partners interested in POS plugin integration.",
-    "path": "cmd/modules/capturePOSWaitlist.cmd.js",
-    "tags": ["onboarding", "partners", "POS"]
-  },
-  "cmd.openWhisperMemory": {
-    "description": "Open the Whisper Memory Panel for reflection, notes, or trust log replay.",
-    "path": "cmd/modules/openWhisperMemory.cmd.js",
-    "tags": ["reflection", "trust", "memory"]
-  },
-  "cmd.spawnVisualGrounderSketch": {
-    "description": "Initiate visual grounding sketch to parse layout photo and auto-generate seating zones.",
-    "path": "cmd/modules/spawnVisualGrounderSketch.cmd.js",
-    "tags": ["visual", "reflex", "layout"]
-  },
-  "cmd.alignMainPortalUI": {
-    "description": "Align the main homepage at hookahplus.net to the updated onboarding, demo, and live flow.",
-    "path": "cmd/modules/alignMainPortalUI.cmd.js",
-    "tags": ["homepage", "UI", "onboarding"]
-  },
-  "cmd.registerLoungeConfig": {
-    "description": "Register YAML configuration for lounge pricing, flavor logic, and QR session mapping.",
-    "path": "cmd/modules/registerLoungeConfig.cmd.js",
-    "tags": ["lounge", "config", "YAML"]
-  },
   "cmd.bundleDeployKit": {
-    "description": "Bundle the deployable UI + metadata kit and push it to GitHub/Netlify automatically.",
-    "path": "cmd/modules/bundleDeployKit.cmd.js",
-    "tags": ["deploy", "kit", "CI/CD"]
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Bundles the deployable UI kit and assets."
   },
   "cmd.switchDomain": {
-    "description": "Switch the live domain to hookahplus.net and apply routing changes.",
-    "path": "cmd/modules/switchDomain.cmd.js",
-    "tags": ["domain", "routing", "live"]
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Simulates switching the live domain to hookahplus.net."
   },
-  "cmd.triggerReflexDeployChainRealignment": {
-    "description": "Log and realign the deploy chain state across Codex, Netlify, and GitHub PR history.",
-    "path": "cmd/modules/triggerReflexDeployChainRealignment.cmd.js",
-    "tags": ["reflex", "deploy", "log"]
+  "cmd.deployFlavorMixUI": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Deploys Flavor Mix History Tracker UI."
   },
- codex/implement-session-time-control-features
+  "cmd.capturePOSWaitlist": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Activates POS Plugin Waitlist capture form."
+  },
+  "cmd.fireSession": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Simulates full Hookah+ session with QR and pricing."
+  },
+  "cmd.openWhisperMemory": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Opens the Whisper Log Memory view."
+  },
+  "cmd.lockTrustDeploy": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Locks the deployment pipeline for a given phase."
+  },
+  "cmd.alignMainPortalUI": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Synchronizes the main portal landing screen."
+  },
+  "cmd.registerLoungeConfig": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Registers YAML configuration for lounge pricing and flavor logic."
+  },
+  "cmd.pushPressKit": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Simulates pushing the latest press kit assets."
+  },
+  "cmd.releaseTeaserVideo": {
+    "path": "cmd/modules/cmd_dispatcher.py",
+    "description": "Publishes the Hookah+ teaser video to public channels."
+  },
+  "cmd.deployReflexUI": {
+    "path": "cmd/modules/reflex_ui.py",
+    "description": "Deploys Reflexive UI via Netlify."
+  },
+  "cmd.renderReflexLoyalty": {
+    "path": "cmd/modules/reflex_ui.py",
+    "description": "Renders loyalty heatmap for a given user."
+  },
+  "cmd.injectReflexHeatmap": {
+    "path": "cmd/modules/reflex_ui.py",
+    "description": "Injects Reflex Heatmap into dashboard."
+  },
+  "cmd.deployToNetlify": {
+    "path": "cmd/modules/reflex_ui.py",
+    "description": "Triggers a Netlify deploy for a given branch."
+  },
   "codex.chronosKairos": {
-    "description": "Agent Chronos_ΔKairos for session timing and reflex decay tracking.",
     "path": "codex/Modules/2025-08-02_chronos_kairos.ts",
-    "tags": ["session", "timer", "reflex"]
-
+    "description": "Agent Chronos_ΔKairos for session timing and reflex decay tracking."
+  },
+  "codex.decaySensor": {
+    "path": "codex/Modules/2025-08-02_decay_sensor.ts",
+    "description": "Utility for computing reflex decay over time."
+  },
   "agent.pricerHermes": {
     "path": "codex/Modules/pricer_hermes.ts",
-    "description": "Dynamic pricing logic with premium detection and margin sync.",
-    "tags": ["pricing", "stripe", "drift"]
- main
+    "description": "Dynamic pricing logic with premium detection and margin sync."
   }
 }

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -4,58 +4,51 @@ import Link from 'next/link';
 import WhisperButton from './WhisperButton';
 
 export default function DemoPage() {
+  const features = [
+    {
+      title: '🕹️ Live Session Simulation',
+      description: 'Preview how customers engage, order, and unlock flavor points.',
+      href: '/live',
+      cta: 'Launch Live Session →',
+    },
+    {
+      title: '🌬️ Flavor Mix Journey',
+      description: 'Explore dynamic flavor combinations and their loyalty effects.',
+      href: '/flavors',
+      cta: 'Try Flavor Flow →',
+    },
+    {
+      title: '📈 Loyalty Dashboard Preview',
+      description: 'View how Hookah+ tracks, scores, and rewards session behavior.',
+      href: '/loyalty',
+      cta: 'View Loyalty Portal →',
+    },
+  ];
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-charcoal via-deepMoss to-charcoal text-goldLumen px-6 py-12 font-sans">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-display font-extrabold tracking-tight">
-          🎬 Demo Preview Portal
-        </h1>
+        <h1 className="text-4xl font-display font-extrabold tracking-tight text-center">🎬 Demo Preview Portal</h1>
         <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
-        <p className="mt-4 text-lg text-goldLumen/80">
+        <p className="mt-4 text-lg text-goldLumen/80 text-center">
           Explore what Hookah+ can unlock in your lounge. This preview simulates real-time session flow, flavor memory, and loyalty intelligence.
         </p>
         <div className="mt-10 grid gap-6 sm:grid-cols-2">
-          <div className="rounded-xl border border-mystic bg-charcoal p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">🕹️ Live Session Simulation</h2>
-            <p className="mt-2 text-goldLumen">
-              Preview how customers engage, order, and unlock flavor points.
-            </p>
-            <Link
-              href="/live"
-              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
-            >
-              Launch Live Session →
-            </Link>
-          </div>
-          <div className="rounded-xl border border-mystic bg-charcoal p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">🌬️ Flavor Mix Journey</h2>
-            <p className="mt-2 text-goldLumen">
-              Explore dynamic flavor combinations and their loyalty effects.
-            </p>
-            <Link
-              href="/flavors"
-              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
-            >
-              Try Flavor Flow →
-            </Link>
-          </div>
-          <div className="rounded-xl border border-mystic bg-charcoal p-6 shadow hover:shadow-xl transition">
-            <h2 className="text-xl font-semibold">📈 Loyalty Dashboard Preview</h2>
-            <p className="mt-2 text-goldLumen">
-              View how Hookah+ tracks, scores, and rewards session behavior.
-            </p>
-            <Link
-              href="/loyalty"
-              className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
-            >
-              View Loyalty Portal →
-            </Link>
-          </div>
+          {features.map((f) => (
+            <div key={f.title} className="rounded-xl border border-mystic bg-charcoal p-6 shadow hover:shadow-xl transition">
+              <h2 className="text-xl font-semibold">{f.title}</h2>
+              <p className="mt-2 text-goldLumen">{f.description}</p>
+              <Link
+                href={f.href}
+                className="mt-4 inline-block text-ember transition-shadow hover:shadow-[0_0_8px_#E8D7B1]"
+              >
+                {f.cta}
+              </Link>
+            </div>
+          ))}
           <div className="rounded-xl border border-mystic bg-charcoal p-6 shadow hover:shadow-xl transition">
             <h2 className="text-xl font-semibold">🧠 Alie Voice Reflex</h2>
-            <p className="mt-2 text-goldLumen">
-              Experience a whisper from Alie guiding session flow.
-            </p>
+            <p className="mt-2 text-goldLumen">Experience a whisper from Alie guiding session flow.</p>
             <WhisperButton />
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,17 +25,20 @@ export default function Home() {
   ];
 
   return (
-    <main className="p-8 flex flex-col items-center space-y-8 font-sans">
-      <h1 className="text-3xl font-display">Welcome to Hookah+</h1>
-      <p className="mt-2 text-center max-w-xl font-sans">
-        Your command center for flavor, flow, and loyalty intelligence.
-      </p>
-      <div className="grid gap-6 md:grid-cols-3">
-        {cards.map((card) => (
-          <ReflexCard key={card.href} {...card} />
-        ))}
+    <main className="min-h-screen bg-gradient-to-br from-charcoal via-deepMoss to-charcoal text-goldLumen px-6 py-12 font-sans">
+      <div className="max-w-5xl mx-auto text-center">
+        <h1 className="text-4xl font-display font-extrabold tracking-tight">Hookah+ Command Center</h1>
+        <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
+        <p className="mt-6 text-lg text-goldLumen/80">Navigate the experience portal: onboarding, demo, and live session.</p>
+        <div className="mt-10 grid gap-6 sm:grid-cols-3">
+          {cards.map((card) => (
+            <ReflexCard key={card.href} {...card} />
+          ))}
+        </div>
+        <div className="mt-12">
+          <WhisperTrigger />
+        </div>
       </div>
-      <WhisperTrigger />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Revamp demo preview page with feature grid and whisper trigger
- Restyle homepage with reflex gradient and navigation cards
- Finalize `CodexModuleMap.json` to match dispatcher modules

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689202e3aa1c8330a9bc4b3fb78e0d97