### PR TITLE
feat: add dashboard card to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,12 @@ import WhisperTrigger from '../components/WhisperTrigger';
 export default function Home() {
   const cards = [
     {
+      title: 'Dashboard',
+      description: 'Monitor operations and insights.',
+      cta: 'View Dashboard',
+      href: '/dashboard',
+    },
+    {
       title: 'Onboarding',
       description: 'Begin the journey and align your lounge.',
       cta: 'Start Onboarding',
@@ -29,7 +35,7 @@ export default function Home() {
       <div className="max-w-5xl mx-auto text-center">
         <h1 className="text-4xl font-display font-extrabold tracking-tight">Hookah+ Command Center</h1>
         <div className="mt-2 h-1 w-32 bg-mystic mx-auto rounded-full animate-pulse" />
-        <p className="mt-6 text-lg text-goldLumen/80">Navigate the experience portal: onboarding, demo, and live session.</p>
+        <p className="mt-6 text-lg text-goldLumen/80">Navigate the experience portal: dashboard, onboarding, demo, and live session.</p>
         <div className="mt-10 grid gap-6 sm:grid-cols-3">
           {cards.map((card) => (
             <ReflexCard key={card.href} {...card} />


### PR DESCRIPTION
## Summary
- add Dashboard card to home page cards array
- mention Dashboard in experience portal description

## Testing
- `npm test`
- `npm run check:palette -- app/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68920d47383c8330b4ce724ee85f91ec