### PR TITLE
feat: move dashboard page to app router

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from 'react';
-import SessionCard, { Session } from '../components/SessionCard';
-import ViewModeToggle, { ViewMode } from '../components/ViewModeToggle';
-import TrustLog from '../components/TrustLog';
-import SessionAnalytics from '../components/SessionAnalytics';
-import OwnerMetrics from '../components/OwnerMetrics';
+import SessionCard, { Session } from '../../components/SessionCard';
+import ViewModeToggle, { ViewMode } from '../../components/ViewModeToggle';
+import TrustLog from '../../components/TrustLog';
+import SessionAnalytics from '../../components/SessionAnalytics';
+import OwnerMetrics from '../../components/OwnerMetrics';
 
 const initialSessions: Session[] = [
   {


### PR DESCRIPTION
## Summary
- move dashboard route from `pages/` to the `app/` router
- fix component import paths for new location

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68920d57d92c8330b9ba4bdc4ec47210