### PR TITLE
fix: hide empty trust notes

### DIFF
--- a/components/TrustLog.tsx
+++ b/components/TrustLog.tsx
@@ -9,11 +9,13 @@ interface Props {
 export default function TrustLog({ sessions }: Props) {
   return (
     <div className="hidden font-sans" aria-hidden>
-      {sessions.map((s) => (
-        <pre key={s.id} data-table={s.table} className="font-mono">
-          {JSON.stringify(s.notes)}
-        </pre>
-      ))}
+      {sessions.map((s) =>
+        s.notes && s.notes.length > 0 ? (
+          <pre key={s.id} data-table={s.table} className="font-mono">
+            {JSON.stringify(s.notes)}
+          </pre>
+        ) : null
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Hide empty notes in TrustLog so only sessions with notes render

## Testing
- `npm test`
- `node -e "const React=require('react'); const ReactDOMServer=require('react-dom/server'); const TrustLog=require('/tmp/test/TrustLog.js').default; const sessions=[{id:1,table:'A1',flavors:['Mint'],startTime:0,refills:0,notes:[]},{id:2,table:'B2',flavors:['Grape'],startTime:0,refills:0,notes:['note']}]; console.log(ReactDOMServer.renderToStaticMarkup(React.createElement(TrustLog,{sessions})))"`

------
https://chatgpt.com/codex/tasks/task_e_68920d70f0648330879504aff91158f0