### PR TITLE
Add reflex overlay components across pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,9 @@ import TrustLog from '../../components/TrustLog';
 import SessionAnalytics from '../../components/SessionAnalytics';
 import OwnerMetrics from '../../components/OwnerMetrics';
 import WhisperTrigger from '../../components/WhisperTrigger';
+import TrustArcDisplay from '../../components/TrustArcDisplay';
+import ReflexPromptModal from '../../components/ReflexPromptModal';
+import MemoryPulseTracker from '../../components/MemoryPulseTracker';
 
 const initialSessions: Session[] = [
   {
@@ -112,10 +115,13 @@ export default function Dashboard() {
         <div className="mt-8">
           <TrustLog sessions={sessions} />
         </div>
-        <div className="mt-8">
+        <div className="mt-8 space-y-4">
           <WhisperTrigger />
+          <ReflexPromptModal />
         </div>
       </div>
+      <TrustArcDisplay score={9.2} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -2,6 +2,10 @@
 
 import Link from 'next/link';
 import WhisperButton from './WhisperButton';
+import WhisperTrigger from '../../components/WhisperTrigger';
+import TrustArcDisplay from '../../components/TrustArcDisplay';
+import ReflexPromptModal from '../../components/ReflexPromptModal';
+import MemoryPulseTracker from '../../components/MemoryPulseTracker';
 
 export default function DemoPage() {
   const features = [
@@ -52,10 +56,16 @@ export default function DemoPage() {
             <WhisperButton />
           </div>
         </div>
+        <div className="mt-8 space-y-4 text-center">
+          <WhisperTrigger />
+          <ReflexPromptModal />
+        </div>
         <div className="mt-12 text-center text-mystic text-sm">
           ⌛ Demo Layer: Reflex Preview Mode | v1.0 | EP Score: 8.7 → awaiting session lock
         </div>
       </div>
+      <TrustArcDisplay score={8.7} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/app/flavors/page.tsx
+++ b/app/flavors/page.tsx
@@ -2,6 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import SelectorAphrodite from './SelectorAphrodite';
+import WhisperTrigger from '../../components/WhisperTrigger';
+import TrustArcDisplay from '../../components/TrustArcDisplay';
+import ReflexPromptModal from '../../components/ReflexPromptModal';
+import MemoryPulseTracker from '../../components/MemoryPulseTracker';
 
 export default function FlavorsPage() {
   const filePath = path.join(process.cwd(), 'data', 'flavor_profiles.yaml');
@@ -12,6 +16,12 @@ export default function FlavorsPage() {
     <div className="p-8 font-sans">
       <h1 className="text-2xl font-display font-bold">Flavor Selector</h1>
       <SelectorAphrodite flavors={flavors} />
+      <div className="mt-8 space-y-4">
+        <WhisperTrigger />
+        <ReflexPromptModal />
+      </div>
+      <TrustArcDisplay score={8.5} />
+      <MemoryPulseTracker />
     </div>
   );
 }

--- a/app/live-session/page.tsx
+++ b/app/live-session/page.tsx
@@ -1,8 +1,19 @@
+import WhisperTrigger from '../../components/WhisperTrigger';
+import TrustArcDisplay from '../../components/TrustArcDisplay';
+import ReflexPromptModal from '../../components/ReflexPromptModal';
+import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+
 export default function LiveSession() {
   return (
     <main className="flex flex-col items-center justify-center min-h-screen p-8 bg-charcoal text-goldLumen font-sans">
       <h1 className="text-3xl font-display font-bold mb-4 text-ember">Join Live Session</h1>
       <p className="font-sans">Connect in real-time with Hookah+ support.</p>
+      <div className="mt-8 space-y-4">
+        <WhisperTrigger />
+        <ReflexPromptModal />
+      </div>
+      <TrustArcDisplay score={8.3} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,8 +1,19 @@
+import WhisperTrigger from '../../components/WhisperTrigger';
+import TrustArcDisplay from '../../components/TrustArcDisplay';
+import ReflexPromptModal from '../../components/ReflexPromptModal';
+import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+
 export default function LivePage() {
   return (
     <main className="p-8 font-sans">
       <h1 className="text-2xl font-display font-bold">Live Session</h1>
       <p className="mt-2 font-sans">Live session interface coming soon.</p>
+      <div className="mt-8 space-y-4">
+        <WhisperTrigger />
+        <ReflexPromptModal />
+      </div>
+      <TrustArcDisplay score={7.9} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from "react";
 import OnboardingModal from "../../components/OnboardingModal";
+import WhisperTrigger from "../../components/WhisperTrigger";
+import TrustArcDisplay from "../../components/TrustArcDisplay";
+import ReflexPromptModal from "../../components/ReflexPromptModal";
+import MemoryPulseTracker from "../../components/MemoryPulseTracker";
 
 export default function Onboarding() {
   const [showModal, setShowModal] = useState(false);
@@ -16,6 +20,12 @@ export default function Onboarding() {
       <h1 className="text-3xl font-display font-bold mb-4 text-ember">Lounge Onboarding</h1>
       <p className="font-sans">Start configuring your lounge with Hookah+.</p>
       {showModal && <OnboardingModal onComplete={() => setShowModal(false)} />}
+      <div className="mt-8 space-y-4">
+        <WhisperTrigger />
+        <ReflexPromptModal />
+      </div>
+      <TrustArcDisplay score={9.0} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/navigation';
 import ReflexCard from '../components/ReflexCard';
 import WhisperTrigger from '../components/WhisperTrigger';
 import OnboardingModal from '../components/OnboardingModal';
+import TrustArcDisplay from '../components/TrustArcDisplay';
+import ReflexPromptModal from '../components/ReflexPromptModal';
+import MemoryPulseTracker from '../components/MemoryPulseTracker';
 import { sessionIgnition } from '../sessionIgnition';
 
 declare const reflex:
@@ -73,11 +76,14 @@ export default function Home() {
             <ReflexCard key={card.title} {...card} />
           ))}
         </div>
-        <div className="mt-12">
+        <div className="mt-12 space-y-4">
           <WhisperTrigger />
+          <ReflexPromptModal />
         </div>
       </div>
       {showOverlay && <OnboardingModal onComplete={handleSessionStart} />}
+      <TrustArcDisplay score={8.9} />
+      <MemoryPulseTracker />
     </main>
   );
 }

--- a/components/MemoryPulseTracker.tsx
+++ b/components/MemoryPulseTracker.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function MemoryPulseTracker() {
+  useEffect(() => {
+    const pulses = Number(localStorage.getItem('memory-pulses') || '0') + 1;
+    localStorage.setItem('memory-pulses', pulses.toString());
+  }, []);
+
+  return <div className="hidden" aria-hidden />;
+}

--- a/components/ReflexPromptModal.tsx
+++ b/components/ReflexPromptModal.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  prompt?: string;
+}
+
+export default function ReflexPromptModal({ prompt = 'Ready to elevate loyalty?' }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-6 px-4 py-2 bg-ember text-charcoal rounded font-sans"
+      >
+        {prompt}
+      </button>
+      {open && (
+        <div className="fixed inset-0 flex items-center justify-center bg-charcoal/80">
+          <div className="bg-deepMoss text-goldLumen p-6 rounded shadow-lg font-sans">
+            <p>Loyalty layer engaged.</p>
+            <button
+              onClick={() => setOpen(false)}
+              className="mt-4 px-4 py-2 bg-ember text-charcoal rounded"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/TrustArcDisplay.tsx
+++ b/components/TrustArcDisplay.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+interface Props {
+  score?: number;
+}
+
+export default function TrustArcDisplay({ score = 0 }: Props) {
+  return (
+    <div className="fixed top-4 right-4 bg-deepMoss text-goldLumen px-4 py-2 rounded shadow font-sans">
+      Trust: {score.toFixed(1)}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TrustArcDisplay, ReflexPromptModal, and MemoryPulseTracker components
- wire reflex overlay hooks into landing and dashboard pages

## Testing
- `npm run check:palette -- app/dashboard/page.tsx app/demo/page.tsx app/flavors/page.tsx app/live-session/page.tsx app/live/page.tsx app/onboarding/page.tsx app/page.tsx components/MemoryPulseTracker.tsx components/ReflexPromptModal.tsx components/TrustArcDisplay.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924d4b74c0833094eb8b0ab58b9f11