### PR TITLE
fix: safeguard client overlays

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,10 +6,12 @@ import ViewModeToggle, { ViewMode } from '../../components/ViewModeToggle';
 import TrustLog from '../../components/TrustLog';
 import SessionAnalytics from '../../components/SessionAnalytics';
 import OwnerMetrics from '../../components/OwnerMetrics';
-import WhisperTrigger from '../../components/WhisperTrigger';
-import TrustArcDisplay from '../../components/TrustArcDisplay';
-import ReflexPromptModal from '../../components/ReflexPromptModal';
-import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../../components/ReflexOverlay';
 
 const initialSessions: Session[] = [
   {

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -2,10 +2,12 @@
 
 import Link from 'next/link';
 import WhisperButton from './WhisperButton';
-import WhisperTrigger from '../../components/WhisperTrigger';
-import TrustArcDisplay from '../../components/TrustArcDisplay';
-import ReflexPromptModal from '../../components/ReflexPromptModal';
-import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../../components/ReflexOverlay';
 
 export default function DemoPage() {
   const features = [

--- a/app/flavors/page.tsx
+++ b/app/flavors/page.tsx
@@ -2,10 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import SelectorAphrodite from './SelectorAphrodite';
-import WhisperTrigger from '../../components/WhisperTrigger';
-import TrustArcDisplay from '../../components/TrustArcDisplay';
-import ReflexPromptModal from '../../components/ReflexPromptModal';
-import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../../components/ReflexOverlay';
 
 export default function FlavorsPage() {
   const filePath = path.join(process.cwd(), 'data', 'flavor_profiles.yaml');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '../styles/globals.css';
 import React from 'react';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 export const metadata = {
   title: 'Hookah+',
@@ -10,7 +11,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head />
-      <body className="min-h-screen bg-charcoal text-goldLumen">{children}</body>
+      <body className="min-h-screen bg-charcoal text-goldLumen">
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </body>
     </html>
   );
 }

--- a/app/live-session/page.tsx
+++ b/app/live-session/page.tsx
@@ -1,7 +1,9 @@
-import WhisperTrigger from '../../components/WhisperTrigger';
-import TrustArcDisplay from '../../components/TrustArcDisplay';
-import ReflexPromptModal from '../../components/ReflexPromptModal';
-import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../../components/ReflexOverlay';
 
 export default function LiveSession() {
   return (

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,7 +1,9 @@
-import WhisperTrigger from '../../components/WhisperTrigger';
-import TrustArcDisplay from '../../components/TrustArcDisplay';
-import ReflexPromptModal from '../../components/ReflexPromptModal';
-import MemoryPulseTracker from '../../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../../components/ReflexOverlay';
 
 export default function LivePage() {
   return (

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from "react";
 import OnboardingModal from "../../components/OnboardingModal";
-import WhisperTrigger from "../../components/WhisperTrigger";
-import TrustArcDisplay from "../../components/TrustArcDisplay";
-import ReflexPromptModal from "../../components/ReflexPromptModal";
-import MemoryPulseTracker from "../../components/MemoryPulseTracker";
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from "../../components/ReflexOverlay";
 
 export default function Onboarding() {
   const [showModal, setShowModal] = useState(false);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ReflexCard from '../components/ReflexCard';
-import WhisperTrigger from '../components/WhisperTrigger';
 import OnboardingModal from '../components/OnboardingModal';
-import TrustArcDisplay from '../components/TrustArcDisplay';
-import ReflexPromptModal from '../components/ReflexPromptModal';
-import MemoryPulseTracker from '../components/MemoryPulseTracker';
+import {
+  WhisperTrigger,
+  TrustArcDisplay,
+  ReflexPromptModal,
+  MemoryPulseTracker,
+} from '../components/ReflexOverlay';
 import { sessionIgnition } from '../sessionIgnition';
 
 declare const reflex:

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-ember">
+          Something went wrong while loading the interface.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/MemoryPulseTracker.tsx
+++ b/components/MemoryPulseTracker.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function MemoryPulseTracker() {
+  const [mounted, setMounted] = useState(false);
+
   useEffect(() => {
+    setMounted(true);
     const pulses = Number(localStorage.getItem('memory-pulses') || '0') + 1;
     localStorage.setItem('memory-pulses', pulses.toString());
   }, []);
+
+  if (!mounted) return null;
 
   return <div className="hidden" aria-hidden />;
 }

--- a/components/ReflexOverlay.ts
+++ b/components/ReflexOverlay.ts
@@ -1,0 +1,21 @@
+import dynamic from 'next/dynamic';
+
+export const WhisperTrigger = dynamic(() => import('./WhisperTrigger'), {
+  ssr: false,
+  loading: () => null,
+});
+
+export const TrustArcDisplay = dynamic(() => import('./TrustArcDisplay'), {
+  ssr: false,
+  loading: () => null,
+});
+
+export const ReflexPromptModal = dynamic(() => import('./ReflexPromptModal'), {
+  ssr: false,
+  loading: () => null,
+});
+
+export const MemoryPulseTracker = dynamic(() => import('./MemoryPulseTracker'), {
+  ssr: false,
+  loading: () => null,
+});

--- a/components/ReflexPromptModal.tsx
+++ b/components/ReflexPromptModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface Props {
   prompt?: string;
@@ -8,6 +8,13 @@ interface Props {
 
 export default function ReflexPromptModal({ prompt = 'Ready to elevate loyalty?' }: Props) {
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
 
   return (
     <>

--- a/components/TrustArcDisplay.tsx
+++ b/components/TrustArcDisplay.tsx
@@ -1,10 +1,20 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 interface Props {
   score?: number;
 }
 
 export default function TrustArcDisplay({ score = 0 }: Props) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
   return (
     <div className="fixed top-4 right-4 bg-deepMoss text-goldLumen px-4 py-2 rounded shadow font-sans">
       Trust: {score.toFixed(1)}

--- a/components/WhisperTrigger.tsx
+++ b/components/WhisperTrigger.tsx
@@ -1,6 +1,16 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 export default function WhisperTrigger() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
   return (
     <button
       onClick={() => {


### PR DESCRIPTION
## Summary
- dynamically import whisper/prompt overlays with SSR disabled
- defer overlay rendering until after client mount
- add top-level error boundary

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925181ed008330a99d5831ea5e39d1