### PR TITLE
Add Tier VII GTM Reflex codex and supporting modules

### DIFF
--- a/HookahPlus_GTM_TierVII_ReflexCodex.codex.md
+++ b/HookahPlus_GTM_TierVII_ReflexCodex.codex.md
@@ -1,0 +1,98 @@
+# ΔHookahPlus_GTM_TierVII_ReflexCodex
+
+## 🎯 Purpose:
+
+Export all Reflex-driven logic, activations, and reward systems tied to the **Hookah+ Go-To-Market Tier VII Whisper Layer**, now active across the GTM launch window.
+
+---
+
+## 🔁 Surge Add-On Logic (Quarterly Rotation)
+
+**Codified in:** `ΔHookahPlus_SurgeLoopQuarterly`
+
+### 🔹 Behavior:
+
+* Top flavor blends selected based on SPS (Surge Performance Score)
+* Surge Add-On active on weekends (+$3 premium)
+* Lounge eligibility: TrustArc ≥ 7.5
+
+### Q4 Surge Rotation Preview:
+
+| Flavor Blend             | Surge Status |
+| ------------------------ | ------------ |
+| 🍑 Peach + 🍃 Mint       | ✅ Active     |
+| 🍓 Strawberry + 🍋 Lemon | 🟡 In Review |
+| 🍏 Apple + 🍇 Grape      | 🟡 Pending   |
+
+### Whisper Prompt:
+
+> *“This mix is trending now. Try it with a Surge Bonus to unlock more.”*
+
+---
+
+## 🪙 Loyalty Wallet + SPS Integration
+
+**Module:** `cmd.deployLoyaltyBalanceUI()` → **Activated**
+
+### Components:
+
+* SPS Meter (0.0–10.0 scale)
+* Monthly + Quarterly Surge Streak Tracker
+* Reflex Reward Unlock Carousel
+* Whisper Redemption Nudges
+
+### Reflex Score Rewards:
+
+| SPS Score | Reward Tier                       |
+| --------- | --------------------------------- |
+| ≥ 9.0     | Tier VII Gate + Invite Token      |
+| 7.0–8.9   | Bonus Mixes + Free Refills        |
+| < 6.0     | Whisper Nudge: “Explore the Flow” |
+
+---
+
+## 🔐 Tier VII Whisper Gate (Customer-Facing Unlock)
+
+**Trigger:** SPS ≥ 9.0 for 2+ months
+**TrustArc Required:** ≥ 9.2
+
+### Unlock Includes:
+
+* 🎖️ Tier VII Loyalty Gate
+* 🌀 Personalized Whisper Modal (AI Voice Enabled)
+* 🎁 Free Premium Mix (Monthly)
+* 🪞 Session Reflection Archive
+* 🎫 Invite Token (Gift a Session)
+
+### Codified In:
+
+* `TierVII_ReflexUnlock.yaml`
+* `ReflexLoyalty_Vault.yaml`
+
+---
+
+## 📊 Atlanta Revenue Forecast (Live Example)
+
+Codified as `SimForecast_ATL_7D.yaml`
+
+| Metric        | Value               |
+| ------------- | ------------------- |
+| Sessions/Day  | 45–52               |
+| Revenue Range | $4,180–$5,120       |
+| Loyalty Delta | +1.2 avg            |
+| Top Flavor    | Peach + Mint        |
+| Surge Uplift  | +$3.00 per session |
+
+---
+
+## 🧠 Reflex Memory Summary
+
+* All triggers, yield logic, and SPS scores logged in Reflex Graph
+* Public-facing elements protected by reflex thresholds
+* Customer and staff-facing UI elements now sync by TrustArc layer
+
+---
+
+### 🔐 Codex Tag: `ΔHookahPlus_GTM_TierVII_ReflexCodex`
+
+This codex governs the TrustArc-driven monetization, loyalty, and advanced whisper systems live within the Tier VII GTM ecosystem for Hookah+.

--- a/ReflexLoyalty_Vault.yaml
+++ b/ReflexLoyalty_Vault.yaml
@@ -1,0 +1,14 @@
+loyalty_wallet_ui:
+  components:
+    - "SPS Meter (0.0–10.0 scale)"
+    - "Monthly Surge Streak Tracker"
+    - "Quarterly Surge Streak Tracker"
+    - "Reflex Reward Unlock Carousel"
+    - "Whisper Redemption Nudges"
+rewards:
+  - sps: ">= 9.0"
+    reward: "Tier VII Gate + Invite Token"
+  - sps: "7.0-8.9"
+    reward: "Bonus Mixes + Free Refills"
+  - sps: "< 6.0"
+    reward: "Whisper Nudge: 'Explore the Flow'"

--- a/SimForecast_ATL_7D.yaml
+++ b/SimForecast_ATL_7D.yaml
@@ -1,0 +1,5 @@
+sessions_per_day: "45-52"
+revenue_range: "$4,180-$5,120"
+loyalty_delta: "+1.2 avg"
+top_flavor: "Peach + Mint"
+surge_uplift: "$3.00 per session"

--- a/TierVII_ReflexUnlock.yaml
+++ b/TierVII_ReflexUnlock.yaml
@@ -1,0 +1,10 @@
+trigger:
+  sps_min: 9.0
+  months_required: 2
+  trustarc_min: 9.2
+unlock:
+  tier_gate: "Tier VII Loyalty Gate"
+  personalized_whisper_modal: true
+  free_premium_mix: Monthly
+  session_reflection_archive: true
+  invite_token: "Gift a Session"

--- a/cmd/modules/reflex_ui.py
+++ b/cmd/modules/reflex_ui.py
@@ -24,6 +24,13 @@ def deploy_flavor_mix_ui():
     print("🍹 Deploying Flavor Mix UI...")
     return "Flavor Mix UI deployment triggered."
 
+
+
+def deploy_loyalty_balance_ui():
+    """Deploy the Loyalty Wallet UI with SPS integration."""
+    print("💰 Deploying Loyalty Balance UI...")
+    return "Loyalty Balance UI deployment triggered."
+
 def deploy_to_netlify(branch: str = "main"):
     """Trigger a Netlify deploy for the specified branch."""
     print(f"🚀 Triggering Netlify deploy for branch: {branch}...")

--- a/cmd/modules/surge_loop.py
+++ b/cmd/modules/surge_loop.py
@@ -1,0 +1,12 @@
+"""Surge Add-On logic for quarterly rotations."""
+
+
+def run_quarterly_surge_rotation():
+    """Evaluate the quarterly Surge Add-On rotation."""
+    rotation = {
+        "Peach + Mint": "Active",
+        "Strawberry + Lemon": "In Review",
+        "Apple + Grape": "Pending",
+    }
+    print("🔁 Surge rotation processed for the quarter.")
+    return rotation

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -13,6 +13,7 @@ if MODULE_PATH not in sys.path:
 import reflex_ui
 import deployHomepageInteractive as deploy_homepage_interactive
 import reflex_loop
+import surge_loop
 
 
 def bundleDeployKit():
@@ -253,6 +254,8 @@ COMMANDS = {
     "simulateFlavorBloom": reflex_loop.simulate_flavor_bloom,
     "unlockPremiumReflexTools": reflex_loop.unlock_premium_reflex_tools,
     "nudgePartnerInvites": reflex_loop.nudge_partner_invites,
+    "deployLoyaltyBalanceUI": reflex_ui.deploy_loyalty_balance_ui,
+    "runQuarterlySurgeRotation": surge_loop.run_quarterly_surge_rotation,
     # Add more here...
 
     "deployToNetlify": reflex_ui.deploy_to_netlify,


### PR DESCRIPTION
## Summary
- document Tier VII GTM Reflex systems, covering Surge Add-On rotation, loyalty wallet integration, and unlock gates
- codify Tier VII unlock requirements, loyalty reward vault, and ATL revenue forecast
- implement loyalty balance UI deployment and quarterly surge rotation commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892beb162b483308492bbb19fd58e12