### PR TITLE
feat: handle partner waitlist uploads

### DIFF
--- a/app/api/partner-waitlist/route.ts
+++ b/app/api/partner-waitlist/route.ts
@@ -2,37 +2,96 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sgMail from '@sendgrid/mail';
 
 export async function POST(req: Request) {
-  const formData = await req.formData();
-  const entry = {
-    name: formData.get('name')?.toString() || '',
-    email: formData.get('email')?.toString() || '',
-    city: formData.get('city')?.toString() || '',
-    pos: formData.get('pos')?.toString() || '',
-    timestamp: new Date().toISOString(),
-  };
+  try {
+    const formData = await req.formData();
+    const entry = {
+      name: formData.get('name')?.toString() || '',
+      email: formData.get('email')?.toString() || '',
+      city: formData.get('city')?.toString() || '',
+      pos: formData.get('pos')?.toString() || '',
+      timestamp: new Date().toISOString(),
+    };
 
-  const logPath = path.join(process.cwd(), 'PartnerSignal_Log.yaml');
-  let existing: any[] = [];
-  if (fs.existsSync(logPath)) {
-    const current = fs.readFileSync(logPath, 'utf8');
-    existing = (yaml.load(current) as any[]) || [];
+    const photo = formData.get('photo') as File | null;
+    const pricing = formData.get('pricing') as File | null;
+
+    if (!photo || !photo.size || !photo.type.startsWith('image/')) {
+      return NextResponse.json(
+        { ok: false, error: 'A valid image is required.' },
+        { status: 400 }
+      );
+    }
+    if (!pricing || !pricing.size || !/\.ya?ml$/i.test(pricing.name)) {
+      return NextResponse.json(
+        { ok: false, error: 'A valid pricing YAML file is required.' },
+        { status: 400 }
+      );
+    }
+
+    const s3 = new S3Client({ region: process.env.AWS_REGION });
+    const bucket = process.env.AWS_S3_BUCKET as string;
+    const timestamp = Date.now();
+
+    const photoKey = `waitlist/photos/${timestamp}-${photo.name}`;
+    const pricingKey = `waitlist/pricing/${timestamp}-${pricing.name}`;
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: photoKey,
+        Body: Buffer.from(await photo.arrayBuffer()),
+        ContentType: photo.type,
+      })
+    );
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: pricingKey,
+        Body: Buffer.from(await pricing.arrayBuffer()),
+        ContentType: 'text/yaml',
+      })
+    );
+
+    const logPath = path.join(process.cwd(), 'PartnerSignal_Log.yaml');
+    let existing: any[] = [];
+    if (fs.existsSync(logPath)) {
+      const current = fs.readFileSync(logPath, 'utf8');
+      existing = (yaml.load(current) as any[]) || [];
+    }
+    existing.push(entry);
+    fs.writeFileSync(logPath, yaml.dump(existing));
+
+    const config = {
+      name: entry.name,
+      city: entry.city,
+      pos: entry.pos,
+    };
+    const configPath = path.join(
+      process.cwd(),
+      'public',
+      'qr_hookahplus_config.yaml'
+    );
+    fs.writeFileSync(configPath, yaml.dump(config));
+
+    sgMail.setApiKey(process.env.SENDGRID_API_KEY || '');
+    await sgMail.send({
+      to: entry.email,
+      from: process.env.SENDGRID_FROM_EMAIL || 'no-reply@example.com',
+      subject: 'HookahPlus Waitlist Confirmation',
+      text: `Thanks for joining the HookahPlus waitlist, ${entry.name}!`,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    console.error(err);
+    return NextResponse.json(
+      { ok: false, error: err.message || 'Internal Server Error' },
+      { status: 500 }
+    );
   }
-  existing.push(entry);
-  fs.writeFileSync(logPath, yaml.dump(existing));
-
-  const config = {
-    name: entry.name,
-    city: entry.city,
-    pos: entry.pos,
-  };
-  const configPath = path.join(
-    process.cwd(),
-    'public',
-    'qr_hookahplus_config.yaml'
-  );
-  fs.writeFileSync(configPath, yaml.dump(config));
-
-  return NextResponse.json({ ok: true });
 }

--- a/components/PartnerWaitlistForm.tsx
+++ b/components/PartnerWaitlistForm.tsx
@@ -3,22 +3,35 @@
 import { useState } from 'react';
 
 export default function PartnerWaitlistForm() {
-  const [submitted, setSubmitted] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    await fetch('/api/partner-waitlist', {
-      method: 'POST',
-      body: formData,
-    });
-    setSubmitted(true);
+    try {
+      const res = await fetch('/api/partner-waitlist', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error || 'Submission failed');
+      }
+      setStatus('success');
+      setMessage(
+        'Thanks for joining the waitlist! Your config file has been generated.'
+      );
+    } catch (err: any) {
+      setStatus('error');
+      setMessage(err.message || 'Something went wrong.');
+    }
   };
 
-  if (submitted) {
+  if (status === 'success') {
     return (
       <p className="mt-4 font-sans text-mystic">
-        Thanks for joining the waitlist! Your config file has been generated.
+        {message}
       </p>
     );
   }
@@ -54,9 +67,12 @@ export default function PartnerWaitlistForm() {
         <option value="Toast">Toast</option>
       </select>
       <div className="text-sm">Seating Photo</div>
-      <input type="file" name="photo" accept="image/*" className="w-full" />
+      <input type="file" name="photo" accept="image/*" className="w-full" required />
       <div className="text-sm">Pricing YAML</div>
-      <input type="file" name="pricing" accept=".yml,.yaml" className="w-full" />
+      <input type="file" name="pricing" accept=".yml,.yaml" className="w-full" required />
+      {status === 'error' && (
+        <p className="text-red-600 text-sm">{message}</p>
+      )}
       <button
         type="submit"
         className="bg-ember text-goldLumen px-4 py-2 rounded w-full"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "echo 'No tests yet'"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.859.0",
+    "@sendgrid/mail": "^8.1.5",
     "js-yaml": "^4.1.0",
     "next": "13.4.19",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- validate and upload waitlist files to S3
- send confirmation email via SendGrid
- surface submission success or failure in the waitlist form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892c20170ec833084f003db1134d8a1