### PR TITLE
Add fifth session to seed data

### DIFF
--- a/scripts/init_db.js
+++ b/scripts/init_db.js
@@ -24,6 +24,7 @@ async function init() {
       ('A1', ARRAY['Mint','Lemon'], NOW() - INTERVAL '50 minutes', 1, ARRAY['likes iced water', 'extra lemon']),
       ('B2', ARRAY['Grape'], NOW() - INTERVAL '16 minutes', 0, ARRAY['no mint requests', 'prefers corner booth', 'check id']),
       ('C3', ARRAY['Watermelon'], NOW() - INTERVAL '10 minutes', 0, ARRAY['first time visitor']),
+      ('D4', ARRAY['Blueberry','Mint'], NOW() - INTERVAL '5 minutes', 0, ARRAY['prefers tall stems', 'ask about specials']),
       ('E5', ARRAY['Peach','Grape','Apple'], NOW() - INTERVAL '70 minutes', 2, ARRAY['watch heat', 'last bowl burnt'])
     `);
   }


### PR DESCRIPTION
## Summary
- extend database seed script with a fifth session record

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost/hookahplus npm run db:seed`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ca98971c8330bff7d10f006347e1