### PR TITLE
Add Stripe app manifest with OAuth scopes

### DIFF
--- a/stripe-app/manifest.yaml
+++ b/stripe-app/manifest.yaml
@@ -1,0 +1,18 @@
+version: 1
+application:
+  name: HookahPlus POS Connector
+  url: https://hookahplus.net
+  support_email: hookahplusconnector@gmail.com
+  privacy_policy_url: https://hookahplus.net/privacy
+  terms_of_service_url: https://hookahplus.net/terms
+oauth:
+  redirect_uris:
+    - https://hookahplus.net/onboarding/stripe/callback
+  scopes:
+    - checkout.sessions:read
+    - checkout.sessions:write
+    - charges:read
+    - products:read
+    - metadata:write
+metadata:
+  release_notes: Initial draft manifest for Stripe app integration.


### PR DESCRIPTION
## Summary
- add initial Stripe app manifest with basic app info and OAuth scopes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892e02a0c8c83308ac55b84c978ba81