### PR TITLE
feat: add stripe app helper commands

### DIFF
--- a/stripe-app/manifest.bundle.json
+++ b/stripe-app/manifest.bundle.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "test_mode": true,
+  "application": {
+    "name": "HookahPlus POS Connector",
+    "url": "https://hookahplus.net",
+    "support_email": "hookahplusconnector@gmail.com",
+    "privacy_policy_url": "https://hookahplus.net/privacy",
+    "terms_of_service_url": "https://hookahplus.net/terms",
+    "onboarding_url": "https://hookahplus.net/onboarding"
+  },
+  "oauth": {
+    "redirect_uris": [
+      "https://hookahplus.net/onboarding/stripe/callback"
+    ],
+    "scopes": [
+      "checkout.sessions:read_write",
+      "charges:read",
+      "products:read",
+      "metadata:write"
+    ]
+  },
+  "metadata": {
+    "release_notes": "Initial draft manifest for Stripe app integration."
+  }
+}

--- a/stripe-app/manifest.yaml
+++ b/stripe-app/manifest.yaml
@@ -1,16 +1,17 @@
 version: 1
+test_mode: true
 application:
   name: HookahPlus POS Connector
   url: https://hookahplus.net
   support_email: hookahplusconnector@gmail.com
   privacy_policy_url: https://hookahplus.net/privacy
   terms_of_service_url: https://hookahplus.net/terms
+  onboarding_url: https://hookahplus.net/onboarding
 oauth:
   redirect_uris:
     - https://hookahplus.net/onboarding/stripe/callback
   scopes:
-    - checkout.sessions:read
-    - checkout.sessions:write
+    - checkout.sessions:read_write
     - charges:read
     - products:read
     - metadata:write


### PR DESCRIPTION
## Summary
- add stripe manifest helper commands for initializing test mode, bundling, deploy, and webhook sync
- enable test mode and onboarding URL in Stripe manifest

## Testing
- `python - <<'PY'
import cmd_dispatcher as cmd
print(cmd.initStripeAppTestMode())
print(cmd.bundleReviewManifest())
print(cmd.deployStripeApp())
print(cmd.runLiveWebhookSync())
PY`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892e445b8a88330bd002289c673d9a3