### PR TITLE
feat: mirror session simulation in public UI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import {
   ReflexPromptModal,
   MemoryPulseTracker,
 } from '../components/ReflexOverlay';
+import SessionReplaySection from '../components/SessionReplaySection';
+import WhisperCatch from '../components/WhisperCatch';
 import { sessionIgnition } from '../sessionIgnition';
 
 declare const reflex:
@@ -86,9 +88,11 @@ export default function Home() {
             <ReflexPromptModal />
           </div>
         </div>
+        <SessionReplaySection />
         {showOverlay && <OnboardingModal onComplete={handleSessionStart} />}
         <TrustArcDisplay score={8.9} />
         <MemoryPulseTracker />
+        <WhisperCatch />
       </main>
     </>
   );

--- a/components/FlavorMemory.tsx
+++ b/components/FlavorMemory.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function FlavorMemory() {
+  const [flavors, setFlavors] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('flavor-memory');
+    if (stored) {
+      try {
+        setFlavors(JSON.parse(stored));
+        return;
+      } catch {
+        // ignore malformed memory
+      }
+    }
+    setFlavors(['Mint Blast', 'Double Apple', 'Blueberry Mist']);
+  }, []);
+
+  return (
+    <div>
+      <h3 className="font-display text-xl text-goldLumen mb-2">Flavor Memory</h3>
+      <ul className="space-y-1">
+        {flavors.map((f) => (
+          <li key={f} className="text-goldLumen/80 font-sans">
+            {f}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/Heatmap.tsx
+++ b/components/Heatmap.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export default function Heatmap() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const { width, height } = canvas;
+    ctx.clearRect(0, 0, width, height);
+    for (let i = 0; i < 12; i++) {
+      const x = Math.random() * width;
+      const y = Math.random() * height;
+      const r = Math.random() * 40 + 20;
+      const gradient = ctx.createRadialGradient(x, y, 0, x, y, r);
+      gradient.addColorStop(0, 'rgba(211,89,48,0.8)'); // ember
+      gradient.addColorStop(1, 'rgba(232,215,177,0)'); // goldLumen
+      ctx.fillStyle = gradient;
+      ctx.fillRect(x - r, y - r, r * 2, r * 2);
+    }
+  }, []);
+
+  return <canvas ref={canvasRef} width={300} height={200} className="w-full h-48 rounded" />;
+}

--- a/components/PublicTrustArcs.tsx
+++ b/components/PublicTrustArcs.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function PublicTrustArcs() {
+  const arcs = [
+    { d: 'M10,90 Q60,10 110,90', color: '#8E79B9' }, // mystic
+    { d: 'M110,90 Q160,10 210,90', color: '#D35930' }, // ember
+  ];
+
+  return (
+    <div className="mt-6">
+      <h3 className="font-display text-xl text-goldLumen mb-2">Public Trust Arcs</h3>
+      <svg viewBox="0 0 220 100" className="w-full h-40">
+        {arcs.map((arc, idx) => (
+          <path key={idx} d={arc.d} stroke={arc.color} strokeWidth={3} fill="none" />
+        ))}
+      </svg>
+      <p className="text-sm text-goldLumen/80 text-center">Lounge Pilot #001</p>
+    </div>
+  );
+}

--- a/components/SessionReplaySection.tsx
+++ b/components/SessionReplaySection.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Heatmap from './Heatmap';
+import FlavorMemory from './FlavorMemory';
+import PublicTrustArcs from './PublicTrustArcs';
+import SessionReplayTimeline from './SessionReplayTimeline';
+
+export default function SessionReplaySection() {
+  return (
+    <section className="mt-20 max-w-5xl mx-auto">
+      <h2 className="text-3xl font-display font-bold text-goldLumen text-center">
+        Replay this Session
+      </h2>
+      <div className="mt-8 grid gap-8 md:grid-cols-2">
+        <div className="bg-charcoal/60 p-4 rounded">
+          <Heatmap />
+          <SessionReplayTimeline />
+        </div>
+        <div className="bg-charcoal/60 p-4 rounded">
+          <FlavorMemory />
+          <PublicTrustArcs />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/WhisperCatch.tsx
+++ b/components/WhisperCatch.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const moments = [
+  { y: 200, text: 'Whisper: Check table 5 heat.' },
+  { y: 600, text: 'Whisper: Mango Dream memory ignited.' },
+];
+
+interface ActiveMoment {
+  y: number;
+  text: string;
+}
+
+export default function WhisperCatch() {
+  const [active, setActive] = useState<ActiveMoment[]>([]);
+  const [seen, setSeen] = useState<number[]>([]);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const scrollY = window.scrollY;
+      moments.forEach((m, idx) => {
+        if (scrollY > m.y && !seen.includes(idx)) {
+          setSeen((prev) => [...prev, idx]);
+          setActive((prev) => [...prev, m]);
+          setTimeout(() => {
+            setActive((prev) => prev.filter((a) => a !== m));
+          }, 4000);
+        }
+      });
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [seen]);
+
+  return (
+    <div className="fixed inset-0 pointer-events-none">
+      {active.map((m, idx) => (
+        <div
+          key={idx}
+          className="absolute left-1/2 top-20 -translate-x-1/2 bg-deepMoss text-goldLumen px-4 py-2 rounded-full opacity-70"
+        >
+          {m.text}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add session replay section with heatmap, flavor memory, and trust arcs
- overlay whisper catch moments that appear on scroll
- wire new replay and whisper features into home page

## Testing
- `npm run check:palette -- app/page.tsx components/FlavorMemory.tsx components/Heatmap.tsx components/PublicTrustArcs.tsx components/SessionReplaySection.tsx components/WhisperCatch.tsx`
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68936463f8c08330adf09dd9821ff88c