### PR TITLE
Implement layered reveal architecture

### DIFF
--- a/components/CodexRenderer.tsx
+++ b/components/CodexRenderer.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function CodexRenderer() {
+  return <div className="mb-4">Codex Renderer</div>;
+}

--- a/components/GhostLogPreview.tsx
+++ b/components/GhostLogPreview.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function GhostLogPreview() {
+  return <div className="mb-4">Ghost Log Preview</div>;
+}

--- a/components/LayeredAccessGate.tsx
+++ b/components/LayeredAccessGate.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React from 'react';
+import PreorderEntry from './PreorderEntry';
+import FlavorSelector from './FlavorSelector';
+import SessionConfirmation from './SessionConfirmation';
+import LoyaltyBadge from './LoyaltyBadge';
+import OperatorDashboard from './OperatorDashboard';
+import SessionTracker from './SessionTracker';
+import SeatMapEditor from './SeatMapEditor';
+import SessionNotesPanel from './SessionNotesPanel';
+import WhisperMemoryLog from './WhisperMemoryLog';
+import ReflexTrustGraph from './ReflexTrustGraph';
+import CodexRenderer from './CodexRenderer';
+import SimulationReplay from './SimulationReplay';
+import GhostLogPreview from './GhostLogPreview';
+import ReflexScoreAudit from './ReflexScoreAudit';
+
+interface User {
+  role?: string;
+  trustTier?: number;
+}
+
+function LayerI() {
+  return (
+    <>
+      <PreorderEntry />
+      <FlavorSelector value="Mint" onChange={() => {}} />
+      <SessionConfirmation flavor="Mint" />
+      <LoyaltyBadge />
+    </>
+  );
+}
+
+function LayerII() {
+  return (
+    <>
+      <OperatorDashboard />
+      <SessionTracker />
+      <SeatMapEditor />
+      <SessionNotesPanel />
+      <WhisperMemoryLog />
+    </>
+  );
+}
+
+function LayerIII() {
+  return (
+    <>
+      <ReflexTrustGraph />
+      <CodexRenderer />
+      <SimulationReplay />
+      <GhostLogPreview />
+      <ReflexScoreAudit />
+    </>
+  );
+}
+
+export default function LayeredAccessGate({ user }: { user: User }) {
+  if (user.role === 'customer') return <LayerI />;
+  else if (user.role === 'operator') return <LayerII />;
+  else if (user.role === 'partner' || (user.trustTier ?? 0) >= 7) return <LayerIII />;
+  return <LayerI />;
+}

--- a/components/LoyaltyBadge.tsx
+++ b/components/LoyaltyBadge.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+export default function LoyaltyBadge() {
+  return (
+    <div className="mt-6 p-2 text-center bg-mystic text-deepMoss">
+      Loyalty points updated
+    </div>
+  );
+}

--- a/components/OperatorDashboard.tsx
+++ b/components/OperatorDashboard.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+export default function OperatorDashboard() {
+  return (
+    <section className="mb-4">
+      <h1 className="text-xl text-goldLumen">Operator Dashboard</h1>
+    </section>
+  );
+}

--- a/components/PreorderEntry.tsx
+++ b/components/PreorderEntry.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+export default function PreorderEntry() {
+  return (
+    <div className="mb-4">
+      <h1 className="text-2xl font-bold text-goldLumen">Start Your Session</h1>
+    </div>
+  );
+}

--- a/components/ReflexScoreAudit.tsx
+++ b/components/ReflexScoreAudit.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function ReflexScoreAudit() {
+  return <div className="mb-4">Reflex Score Audit</div>;
+}

--- a/components/ReflexTrustGraph.tsx
+++ b/components/ReflexTrustGraph.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function ReflexTrustGraph() {
+  return <div className="mb-4">Reflex Trust Graph</div>;
+}

--- a/components/SeatMapEditor.tsx
+++ b/components/SeatMapEditor.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function SeatMapEditor() {
+  return <div className="mb-4">Seat Map Editor Placeholder</div>;
+}

--- a/components/SessionConfirmation.tsx
+++ b/components/SessionConfirmation.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+
+interface Props {
+  flavor: string;
+}
+
+export default function SessionConfirmation({ flavor }: Props) {
+  return (
+    <div className="mt-4 p-4 border border-ember text-goldLumen">
+      <p>Session confirmed with {flavor} flavor.</p>
+    </div>
+  );
+}

--- a/components/SessionNotesPanel.tsx
+++ b/components/SessionNotesPanel.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function SessionNotesPanel() {
+  return <div className="mb-4">Session Notes Panel Placeholder</div>;
+}

--- a/components/SessionTracker.tsx
+++ b/components/SessionTracker.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function SessionTracker() {
+  return <div className="mb-4">Session Tracker Placeholder</div>;
+}

--- a/components/SimulationReplay.tsx
+++ b/components/SimulationReplay.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function SimulationReplay() {
+  return <div className="mb-4">Simulation Replay</div>;
+}

--- a/components/WhisperMemoryLog.tsx
+++ b/components/WhisperMemoryLog.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import React from 'react';
+
+export default function WhisperMemoryLog() {
+  return <div className="mb-4">Whisper Memory Log</div>;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const role = req.cookies.get('role')?.value;
+  const trust = parseInt(req.cookies.get('trustTier')?.value || '0', 10);
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/dashboard/operator') && role !== 'operator') {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
+  if (pathname.startsWith('/vault') && !(role === 'partner' || trust >= 7)) {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/operator/:path*', '/vault/:path*'],
+};

--- a/pages/dashboard/operator.tsx
+++ b/pages/dashboard/operator.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import OperatorDashboard from '../../components/OperatorDashboard';
+import SessionTracker from '../../components/SessionTracker';
+import SeatMapEditor from '../../components/SeatMapEditor';
+import SessionNotesPanel from '../../components/SessionNotesPanel';
+import WhisperMemoryLog from '../../components/WhisperMemoryLog';
+
+export default function OperatorRoute() {
+  return (
+    <main className="p-4">
+      <OperatorDashboard />
+      <SessionTracker />
+      <SeatMapEditor />
+      <SessionNotesPanel />
+      <WhisperMemoryLog />
+    </main>
+  );
+}

--- a/pages/preorder.tsx
+++ b/pages/preorder.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import PreorderEntry from '../components/PreorderEntry';
+import FlavorSelector from '../components/FlavorSelector';
+import SessionConfirmation from '../components/SessionConfirmation';
+import LoyaltyBadge from '../components/LoyaltyBadge';
+
+export default function PreorderPage() {
+  const [flavor, setFlavor] = useState('Mint');
+  const [confirmed, setConfirmed] = useState(false);
+
+  return (
+    <main className="p-4">
+      <PreorderEntry />
+      <FlavorSelector value={flavor} onChange={setFlavor} />
+      <button className="mt-4 px-4 py-2 bg-ember text-goldLumen" onClick={() => setConfirmed(true)}>
+        Checkout
+      </button>
+      {confirmed && <SessionConfirmation flavor={flavor} />}
+      <LoyaltyBadge />
+    </main>
+  );
+}

--- a/pages/vault/index.tsx
+++ b/pages/vault/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReflexTrustGraph from '../../components/ReflexTrustGraph';
+import CodexRenderer from '../../components/CodexRenderer';
+import SimulationReplay from '../../components/SimulationReplay';
+import GhostLogPreview from '../../components/GhostLogPreview';
+import ReflexScoreAudit from '../../components/ReflexScoreAudit';
+
+export default function VaultIndex() {
+  return (
+    <main className="p-4">
+      <ReflexTrustGraph />
+      <CodexRenderer />
+      <SimulationReplay />
+      <GhostLogPreview />
+      <ReflexScoreAudit />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce preorder, operator dashboard, and vault pages for customer, staff, and partner layers
- Add LayeredAccessGate component to reveal layers based on role and trust tier
- Enforce trust-aware routing with middleware and supporting components

## Testing
- `npm run check:palette -- components/CodexRenderer.tsx components/GhostLogPreview.tsx components/LayeredAccessGate.tsx components/LoyaltyBadge.tsx components/OperatorDashboard.tsx components/PreorderEntry.tsx components/ReflexScoreAudit.tsx components/ReflexTrustGraph.tsx components/SeatMapEditor.tsx components/SessionConfirmation.tsx components/SessionNotesPanel.tsx components/SessionTracker.tsx components/SimulationReplay.tsx components/WhisperMemoryLog.tsx pages/preorder.tsx pages/dashboard/operator.tsx pages/vault/index.tsx middleware.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893653f49388330bf9c7525cb732a94