### PR TITLE
feat: add codex reflex sync mode

### DIFF
--- a/components/CodexRenderer.tsx
+++ b/components/CodexRenderer.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+
+interface CodexEntry {
+  title: string;
+  triggers: string[];
+  summary: string;
+  reflexScore: number;
+  time: string;
+}
+
+interface Props {
+  limit?: number;
+  offset?: number;
+}
+
+// Fetch and display Codex entries as a vertical timeline feed.
+export default function CodexRenderer({ limit, offset }: Props) {
+  const [entries, setEntries] = useState<CodexEntry[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/codex-entries');
+        const data: CodexEntry[] = await res.json();
+        let list = data;
+        if (offset) list = list.slice(offset);
+        if (limit) list = list.slice(0, limit);
+        setEntries(list);
+      } catch (e) {
+        console.error('Failed to load Codex entries', e);
+      }
+    }
+    load();
+  }, [limit, offset]);
+
+  return (
+    <div className="codex-feed">
+      {entries.map((entry, idx) => (
+        <div key={idx} className="codex-card">
+          <h3 className="codex-title">{entry.title}</h3>
+          <div className="codex-triggers">
+            {entry.triggers.join(', ')}
+          </div>
+          <p className="codex-summary">{entry.summary}</p>
+          <div className="codex-meta">
+            <span className="codex-score">Reflex Score: {entry.reflexScore}</span>
+            <span className="codex-time">
+              {new Date(entry.time).toLocaleString()}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/ReflexEventToCard.tsx
+++ b/components/ReflexEventToCard.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+interface ReflexEvent {
+  type: 'system' | 'whisper' | 'replay';
+  trigger?: string;
+  message: string;
+  timestamp: string;
+}
+
+// Poll the ReflexLog and render events as cards.
+export default function ReflexEventToCard() {
+  const [events, setEvents] = useState<ReflexEvent[]>([]);
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        const res = await fetch('/api/reflex-log');
+        const data: ReflexEvent[] = await res.json();
+        setEvents(data.slice(-15));
+      } catch (e) {
+        console.error('Failed to load Reflex events', e);
+      }
+    };
+    fetchEvents();
+    const id = setInterval(fetchEvents, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const colorMap: Record<ReflexEvent['type'], string> = {
+    system: 'reflex-system',
+    whisper: 'reflex-whisper',
+    replay: 'reflex-replay',
+  };
+  const iconMap: Record<ReflexEvent['type'], string> = {
+    system: '🔥',
+    whisper: '💬',
+    replay: '🌀',
+  };
+
+  return (
+    <div className="reflex-feed">
+      {events.map((ev, idx) => (
+        <div key={idx} className={`reflex-card ${colorMap[ev.type]}`}>
+          <span className="reflex-icon">{iconMap[ev.type]}</span>
+          <div className="reflex-content">
+            <div className="reflex-message">{ev.message}</div>
+            <div className="reflex-meta">
+              {ev.trigger && <span className="reflex-trigger">{ev.trigger}</span>}
+              <span className="reflex-time">
+                {new Date(ev.timestamp).toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/data/ReflexLog.json
+++ b/data/ReflexLog.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "system",
+    "trigger": "cmd.transmuteSimulationToProd()",
+    "message": "Simulation promoted to production",
+    "timestamp": "2025-08-06T01:00:00Z"
+  },
+  {
+    "type": "whisper",
+    "trigger": "Whisper: open logs",
+    "message": "Whisper event captured",
+    "timestamp": "2025-08-06T02:00:00Z"
+  },
+  {
+    "type": "replay",
+    "trigger": "Replay moment",
+    "message": "Replay system engaged",
+    "timestamp": "2025-08-06T03:00:00Z"
+  }
+]

--- a/data/codex_entries/2025-08-06_smoke.yaml
+++ b/data/codex_entries/2025-08-06_smoke.yaml
@@ -1,0 +1,7 @@
+title: "The Day the Simulation Breathed Smoke"
+triggers:
+  - "cmd.transmuteSimulationToProd()"
+summary: |
+  If the lounge remembers the smoke, the system remembers the soul.
+reflexScore: 9.1
+time: "2025-08-06T00:00:00Z"

--- a/pages/api/codex-entries.ts
+++ b/pages/api/codex-entries.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const dir = path.join(process.cwd(), 'data', 'codex_entries');
+  const files = fs.readdirSync(dir);
+  const entries = files.map((file) => {
+    const filePath = path.join(dir, file);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const data = file.endsWith('.yaml') || file.endsWith('.yml')
+      ? (yaml.load(raw) as any)
+      : JSON.parse(raw);
+    return data;
+  });
+  entries.sort(
+    (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime()
+  );
+  res.status(200).json(entries);
+}

--- a/pages/api/reflex-log.ts
+++ b/pages/api/reflex-log.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const filePath = path.join(process.cwd(), 'data', 'ReflexLog.json');
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const events = JSON.parse(raw);
+  res.status(200).json(events);
+}

--- a/pages/codex.tsx
+++ b/pages/codex.tsx
@@ -1,0 +1,24 @@
+import CodexRenderer from '../components/CodexRenderer';
+import ReflexEventToCard from '../components/ReflexEventToCard';
+import '../styles/codex.css';
+
+export default function CodexPage() {
+  return (
+    <div className="codex-page">
+      <section>
+        <h1 className="codex-heading">Today's Codex Entry</h1>
+        <CodexRenderer limit={1} />
+      </section>
+      <section>
+        <h2 className="codex-heading">Recent Activations</h2>
+        <div className="codex-scroll">
+          <CodexRenderer offset={1} limit={15} />
+          <ReflexEventToCard />
+        </div>
+      </section>
+      <div className="codex-cta">
+        Want to see what built this system? <span className="codex-link">View the Codex.</span>
+      </div>
+    </div>
+  );
+}

--- a/styles/codex.css
+++ b/styles/codex.css
@@ -1,0 +1,60 @@
+.codex-page {
+  padding: 2rem;
+  font-family: sans-serif;
+}
+.codex-heading {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+.codex-feed, .reflex-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.codex-card, .reflex-card {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: #111;
+  color: #eee;
+}
+.codex-triggers, .reflex-trigger {
+  font-style: italic;
+  margin-bottom: 0.25rem;
+}
+.codex-meta, .reflex-meta {
+  font-size: 0.875rem;
+  opacity: 0.8;
+  display: flex;
+  justify-content: space-between;
+}
+.codex-scroll {
+  max-height: 60vh;
+  overflow-y: auto;
+  border-top: 1px solid #333;
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+.codex-cta {
+  margin-top: 2rem;
+  text-align: center;
+}
+.codex-link {
+  text-decoration: underline;
+  cursor: pointer;
+}
+.reflex-system {
+  background: #331111;
+}
+.reflex-whisper {
+  background: #112233;
+}
+.reflex-replay {
+  background: #113311;
+}
+.reflex-icon {
+  margin-right: 0.5rem;
+}
+.reflex-card {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- add CodexRenderer and ReflexEventToCard components for CodexReflex sync mode
- expose API routes to read codex entries and reflex logs
- create codex page, styles, and sample data for initial entry and reflex events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893655bb62c83308ccc9a812f97699f