### PR TITLE
feat: introduce whisper overlay engine

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
   ReflexPromptModal,
   MemoryPulseTracker,
 } from '../../components/ReflexOverlay';
+import WhisperOverlayEngine from '../../components/WhisperOverlayEngine';
 
 export default function Dashboard() {
   const [mode, setMode] = useState<ViewMode>('staff');
@@ -84,6 +85,7 @@ export default function Dashboard() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-charcoal via-deepMoss to-charcoal text-goldLumen font-sans p-6">
+      <WhisperOverlayEngine />
       <div className="max-w-6xl mx-auto">
         <h1 className="text-3xl font-display font-bold mb-6 text-ember text-center">
           Flavor Flow Dashboard

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import '../styles/whisper.css';
 import React from 'react';
 import ErrorBoundary from '../components/ErrorBoundary';
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import {
   ReflexPromptModal,
   MemoryPulseTracker,
 } from '../components/ReflexOverlay';
+import WhisperOverlayEngine from '../components/WhisperOverlayEngine';
 import { sessionIgnition } from '../sessionIgnition';
 
 declare const reflex:
@@ -70,6 +71,7 @@ export default function Home() {
   return (
     <>
       <StickyNav onStartSession={() => setShowOverlay(true)} />
+      <WhisperOverlayEngine />
       <main className="min-h-screen bg-gradient-to-br from-charcoal via-deepMoss to-charcoal text-goldLumen px-6 py-12 font-sans">
         <div className="max-w-5xl mx-auto text-center">
           <h1 className="text-4xl font-display font-extrabold tracking-tight">Hookah+</h1>

--- a/components/FloatingEcho.tsx
+++ b/components/FloatingEcho.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+interface FloatingEchoProps {
+  message: string;
+}
+
+export default function FloatingEcho({ message }: FloatingEchoProps) {
+  return <div className="whisper-message floating-echo">{message}</div>;
+}

--- a/components/WhisperMemoryLink.tsx
+++ b/components/WhisperMemoryLink.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface WhisperMemoryLinkProps {
+  moment: string;
+}
+
+export default function WhisperMemoryLink({ moment }: WhisperMemoryLinkProps) {
+  useEffect(() => {
+    // Placeholder for linking to SessionNotes, ReflexLog.json, LoyaltyBadgeHistory.yaml
+    console.log('Whisper moment linked:', moment);
+  }, [moment]);
+
+  return null;
+}

--- a/components/WhisperOverlayEngine.tsx
+++ b/components/WhisperOverlayEngine.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import FloatingEcho from './FloatingEcho';
+import WhisperMemoryLink from './WhisperMemoryLink';
+import { scrollTriggers, clickTriggers } from '../utils/WhisperTriggerMap';
+
+interface Whisper {
+  id: number;
+  text: string;
+}
+
+let idCounter = 0;
+
+export default function WhisperOverlayEngine() {
+  const [whispers, setWhispers] = useState<Whisper[]>([]);
+  const triggeredScroll = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      const percent = Math.round((window.scrollY / scrollHeight) * 100);
+      Object.entries(scrollTriggers).forEach(([threshold, text]) => {
+        const t = Number(threshold);
+        if (percent >= t && !triggeredScroll.current.has(t)) {
+          triggeredScroll.current.add(t);
+          pushWhisper(text);
+        }
+      });
+    };
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const key = target.dataset.whisper;
+      if (key && clickTriggers[key]) {
+        pushWhisper(clickTriggers[key]);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    document.addEventListener('click', handleClick);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('click', handleClick);
+    };
+  }, []);
+
+  const pushWhisper = (text: string) => {
+    const id = ++idCounter;
+    setWhispers((prev) => [...prev, { id, text }]);
+    setTimeout(() => {
+      setWhispers((prev) => prev.filter((w) => w.id !== id));
+    }, 4000);
+  };
+
+  return (
+    <div className="whisper-overlay">
+      {whispers.map((w) => (
+        <div key={w.id}>
+          <FloatingEcho message={w.text} />
+          <WhisperMemoryLink moment={w.text} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/data/LoyaltyBadgeHistory.yaml
+++ b/data/LoyaltyBadgeHistory.yaml
@@ -1,0 +1,4 @@
+loyalty_badges:
+  - flavor: Mint
+    repeats: 3
+    note: "Mint badge glows again"

--- a/styles/whisper.css
+++ b/styles/whisper.css
@@ -1,0 +1,32 @@
+.whisper-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 50;
+}
+
+.whisper-message {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 1rem;
+  margin: 1rem;
+  animation: fadeMove 4s ease-out forwards;
+}
+
+.floating-echo {
+  animation: echoFloat 6s ease-in-out forwards;
+}
+
+@keyframes fadeMove {
+  0% { opacity: 0; transform: translateY(10px); }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-10px); }
+}
+
+@keyframes echoFloat {
+  0% { opacity: 0; transform: translateY(0); }
+  10% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-40px); }
+}

--- a/utils/WhisperTriggerMap.ts
+++ b/utils/WhisperTriggerMap.ts
@@ -1,0 +1,11 @@
+export const scrollTriggers: Record<number, string> = {
+  25: "This flavor feels familiar...",
+  50: "Halfway there. Trust is forming.",
+  75: "Almost through. Loyalty is near.",
+};
+
+export const clickTriggers: Record<string, string> = {
+  flavor: "They've chosen Mint 3 times this week. Echo their trust.",
+  repeatOrder: "Back again? Whispering loyalty.",
+  sessionComplete: "Session complete. Memory archived.",
+};


### PR DESCRIPTION
## Summary
- add WhisperOverlayEngine to broadcast scroll and click whispers
- surface loyalty echoes with FloatingEcho and memory links
- wire WhisperLayer across home and dashboard

## Testing
- `npm test`
- `npm run build` *(fails: Module not found: Can't resolve 'debug' in 'node_modules/follow-redirects')*

------
https://chatgpt.com/codex/tasks/task_e_689365df2aa48330a450d1ee5af66853