### PR TITLE
fix: clean CodexRenderer and homepage syntax errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,12 +11,10 @@ import {
   ReflexPromptModal,
   MemoryPulseTracker,
 } from '../components/ReflexOverlay';
- codex/add-global-whisperlayer-ui-support
 import WhisperOverlayEngine from '../components/WhisperOverlayEngine';
 
 import SessionReplaySection from '../components/SessionReplaySection';
 import WhisperCatch from '../components/WhisperCatch';
- main
 import { sessionIgnition } from '../sessionIgnition';
 
 declare const reflex:

--- a/components/CodexRenderer.tsx
+++ b/components/CodexRenderer.tsx
@@ -1,5 +1,6 @@
- codex/activate-codexreflex-sync-mode
-import { useEffect, useState } from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 
 interface CodexEntry {
   title: string;
@@ -39,9 +40,7 @@ export default function CodexRenderer({ limit, offset }: Props) {
       {entries.map((entry, idx) => (
         <div key={idx} className="codex-card">
           <h3 className="codex-title">{entry.title}</h3>
-          <div className="codex-triggers">
-            {entry.triggers.join(', ')}
-          </div>
+          <div className="codex-triggers">{entry.triggers.join(', ')}</div>
           <p className="codex-summary">{entry.summary}</p>
           <div className="codex-meta">
             <span className="codex-score">Reflex Score: {entry.reflexScore}</span>
@@ -53,12 +52,4 @@ export default function CodexRenderer({ limit, offset }: Props) {
       ))}
     </div>
   );
-
-'use client';
-
-import React from 'react';
-
-export default function CodexRenderer() {
-  return <div className="mb-4">Codex Renderer</div>;
- main
 }


### PR DESCRIPTION
## Summary
- remove stray codex directives and duplicate component definitions in `CodexRenderer`
- clean up homepage imports by removing embedded codex marker lines

## Testing
- `npm test`
- `npm run build` *(fails: module not found 'debug' warning but build produces output)*

------
https://chatgpt.com/codex/tasks/task_e_689368d8d06c833097c4ab386a2cc2c6