### PR TITLE
feat: log reflex commands to codex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Run Reflex Command Dispatcher
         run: |
           python cmd_dispatcher.py "${{ github.event.inputs.command }}"
-                - name: Commit Codex Log Update
+
+      - name: Commit Codex Log Update
         run: |
           mkdir -p codex/logs
           cp codex_command_log.txt codex/logs/command_history.log || true

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -1,5 +1,15 @@
 import sys
 import time
+import datetime
+import os
+
+def log_to_codex(command: str):
+    timestamp = datetime.datetime.utcnow().isoformat()
+    log_entry = f"[{timestamp}] Executed Command: {command}\n"
+    log_file_path = os.path.join(os.getcwd(), "codex_command_log.txt")
+    with open(log_file_path, "a") as f:
+        f.write(log_entry)
+    print(f"🔹 Logged to Codex: {log_entry.strip()}")
 
 # === Phase I Reflex Commands ===
 def cmd_syncCodexToSite():
@@ -108,6 +118,9 @@ def run_command(input_command):
     else:
         print(f"❌ Unknown command: {command}")
         print("💡 Tip: Check spelling or implement it in cmd_dispatcher.py.")
+
+    # Always log the command execution
+    log_to_codex(command)
 
 # Entry point
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log executed commands with timestamps in `cmd_dispatcher.py`
- commit Codex command logs back to repo from GitHub Actions

## Testing
- `npm test`
- `python -m py_compile cmd_dispatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68937ebae50c8330a59777fbe36e5624