### PR TITLE
Add MoodBook Sora overlay codex and dashboard theme control

### DIFF
--- a/HookahPlus_MoodBook_SoraOverlay_v1.codex.md
+++ b/HookahPlus_MoodBook_SoraOverlay_v1.codex.md
@@ -1,0 +1,75 @@
+# MoodBook_SoraOverlay_v1
+
+## 📘 Codex Entry: Apply MoodBook Theme via Sora Reflex Engine
+
+**Intent**
+Enable all agents (UI, voice, memory, or system logic agents) to render and align MoodBook themes across the Hookah+ experience — dynamically adjusting tone, color, animation, and micro-interactions based on the selected mood.
+
+### 🎛️ Reflex Trigger Schema
+
+```
+codex:
+  id: moodbook_sora_overlay_v1
+  mode: auto-sync
+  activated_by: ["cmd.setMood()", "user.preference.moodState", "reflex.trigger.moodShift"]
+  targets:
+    - sora.overlay.theme
+    - ui.colorPalette
+    - background.animation
+    - whisperLayer.mood
+    - memoryEcho.visual
+    - dashboard.moodRing
+
+moodBookThemes:
+  - name: "Glow"
+    tone: "uplifting"
+    palette: ["#FFD36E", "#FF7F50", "#FCE38A"]
+    animation: "pulsingLight"
+    soundscape: "softBassWaves"
+  
+  - name: "Stillness"
+    tone: "calm, reflective"
+    palette: ["#B0E0E6", "#FFFFFF", "#D3D3D3"]
+    animation: "slowFade"
+    soundscape: "rainChimes"
+
+  - name: "Midnight Ember"
+    tone: "moody, luxurious"
+    palette: ["#1A1A2E", "#C06C84", "#355C7D"]
+    animation: "embersGlow"
+    soundscape: "deepAmbient"
+
+  - name: "Alive"
+    tone: "energetic, confident"
+    palette: ["#7EFFC1", "#FF6B6B", "#FFFA65"]
+    animation: "sparkleBounce"
+    soundscape: "futureFunkLoop"
+```
+
+### 🧠 Agent Integration Logic (Pseudocode)
+
+```
+function applyMoodBook(themeName) {
+  const theme = moodBookThemes[themeName];
+  Sora.overlay.updatePalette(theme.palette);
+  Sora.setTone(theme.tone);
+  UI.animateBackground(theme.animation);
+  WhisperLayer.setMoodResonance(theme.tone);
+  ReflexMemory.displayEchoEffect(themeName);
+}
+```
+
+### 🔁 Reflex Loop Scenarios
+
+| Trigger Source | Mood | Outcome |
+| -------------- | ---- | ------- |
+| User feedback: "Vibe felt off today" | Stillness | Calm visuals, slower transitions, faded whispers |
+| Session peak memory scored 9.5 | Alive | Bright accents, bounce animations, celebratory echo |
+| Session slow start, low engagement | Glow | Gradual warmth, invite overlays, positive tone |
+| User visits memory replay | Midnight Ember | Reflective visuals, ambient layers, low-light mode |
+
+### 🛠️ Optional Reflex Command
+
+```
+cmd.setMood("Midnight Ember")
+```

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import TrustLog from '../../components/TrustLog';
 import SessionAnalytics from '../../components/SessionAnalytics';
 import OwnerMetrics from '../../components/OwnerMetrics';
 import LoyaltyWallet from '../../components/LoyaltyWallet';
+import MoodBookOverlay from '../../components/MoodBookOverlay';
 import {
   WhisperTrigger,
   TrustArcDisplay,
@@ -94,6 +95,7 @@ export default function Dashboard() {
         <div className="mt-4 mb-6 flex justify-center">
           <LoyaltyWallet />
         </div>
+        <MoodBookOverlay />
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 max-h-[70vh] overflow-y-auto pr-2">
           {sessions.map((session) => (
             <SessionCard

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -57,6 +57,11 @@ def cmd_autoGenerateSoraWelcomeReels():
     time.sleep(1)
     print("✅ Welcome reels deployed and linked to onboarding.")
 
+def cmd_setMood():
+    print("🎨 Setting MoodBook theme via Sora...")
+    time.sleep(1)
+    print("✅ MoodBook theme applied across surfaces.")
+
 # === Phase II Reflex Expansion Commands ===
 def cmd_scanTrustLog():
     print("🔎 Scanning ReflexLog.json for trust decay signals...")
@@ -103,6 +108,7 @@ def run_command(input_command):
         "cmd.deploySoraMemoryLayer": cmd_deploySoraMemoryLayer,
         "cmd.syncSoraReelsToCodexReflexSnapshots": cmd_syncSoraReelsToCodexReflexSnapshots,
         "cmd.autoGenerateSoraWelcomeReels": cmd_autoGenerateSoraWelcomeReels,
+        "cmd.setMood": cmd_setMood,
 
         # Phase II
         "cmd.scanTrustLog": cmd_scanTrustLog,

--- a/codex/Modules/moodbook_sora_overlay_v1.ts
+++ b/codex/Modules/moodbook_sora_overlay_v1.ts
@@ -1,0 +1,49 @@
+export interface MoodBookTheme {
+  name: string;
+  tone: string;
+  palette: string[];
+  animation: string;
+  soundscape: string;
+}
+
+export const moodBookThemes: MoodBookTheme[] = [
+  {
+    name: 'Glow',
+    tone: 'uplifting',
+    palette: ['#FFD36E', '#FF7F50', '#FCE38A'],
+    animation: 'pulsingLight',
+    soundscape: 'softBassWaves',
+  },
+  {
+    name: 'Stillness',
+    tone: 'calm, reflective',
+    palette: ['#B0E0E6', '#FFFFFF', '#D3D3D3'],
+    animation: 'slowFade',
+    soundscape: 'rainChimes',
+  },
+  {
+    name: 'Midnight Ember',
+    tone: 'moody, luxurious',
+    palette: ['#1A1A2E', '#C06C84', '#355C7D'],
+    animation: 'embersGlow',
+    soundscape: 'deepAmbient',
+  },
+  {
+    name: 'Alive',
+    tone: 'energetic, confident',
+    palette: ['#7EFFC1', '#FF6B6B', '#FFFA65'],
+    animation: 'sparkleBounce',
+    soundscape: 'futureFunkLoop',
+  },
+];
+
+export function applyMoodBook(themeName: string) {
+  const theme = moodBookThemes.find((t) => t.name === themeName);
+  if (!theme) return;
+  const root = document.documentElement;
+  theme.palette.forEach((color, idx) => {
+    root.style.setProperty(`--mood-color-${idx + 1}`, color);
+  });
+  root.dataset.moodTone = theme.tone;
+  console.log(`MoodBook theme applied: ${theme.name}`);
+}

--- a/components/MoodBookOverlay.tsx
+++ b/components/MoodBookOverlay.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { useState } from 'react';
+import { moodBookThemes, applyMoodBook } from '../codex/Modules/moodbook_sora_overlay_v1';
+
+export default function MoodBookOverlay() {
+  const [theme, setTheme] = useState(moodBookThemes[0].name);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newTheme = e.target.value;
+    setTheme(newTheme);
+    applyMoodBook(newTheme);
+  };
+
+  return (
+    <div className="p-4 bg-charcoal rounded text-goldLumen mb-6">
+      <label className="block mb-2 font-semibold">MoodBook Theme</label>
+      <select
+        value={theme}
+        onChange={handleChange}
+        className="bg-charcoal border border-ember rounded p-2"
+      >
+        {moodBookThemes.map((t) => (
+          <option key={t.name} value={t.name}>
+            {t.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/data/codex_entries/2025-08-07_moodbook_sora_overlay.yaml
+++ b/data/codex_entries/2025-08-07_moodbook_sora_overlay.yaml
@@ -1,0 +1,10 @@
+title: "Apply MoodBook Theme via Sora Reflex Engine"
+triggers:
+  - "cmd.setMood()"
+  - "user.preference.moodState"
+  - "reflex.trigger.moodShift"
+summary: |
+  Enables agents to align MoodBook themes across Hookah+, syncing tone, palette,
+  animation, and soundscape through the Sora overlay engine.
+reflexScore: 9.3
+time: "2025-08-07T00:00:00Z"


### PR DESCRIPTION
## Summary
- document MoodBook Sora overlay codex entry with trigger schema and themes
- add MoodBook theme module and dashboard selector to apply themes
- support `cmd.setMood` CLI command for Sora overlay

## Testing
- `npm test`
- `npm run build` *(warn: Can't resolve 'debug' in follow-redirects)*

------
https://chatgpt.com/codex/tasks/task_e_6893af5963b08330aa08bb9fddd0164b