### PR TITLE
🧩 Codex Repair: ΔReflexSync_BindPatch

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,10 +16,7 @@ import WhisperOverlayEngine from '../components/WhisperOverlayEngine';
 import SessionReplaySection from '../components/SessionReplaySection';
 import WhisperCatch from '../components/WhisperCatch';
 import { sessionIgnition } from '../sessionIgnition';
-
-declare const reflex:
-  | { logEvent: (event: string, payload: Record<string, unknown>) => void }
-  | undefined;
+import { reflex } from '../lib/reflex';
 
 export default function Home() {
   const router = useRouter();

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { reflex } from '../lib/reflex';
 
 interface Props {
   children: React.ReactNode;
@@ -21,6 +22,14 @@ export default class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    try {
+      reflex?.logEvent?.('error_boundary_triggered', {
+        error: String(error),
+        info,
+      });
+    } catch (e) {
+      console.warn('Reflex failed to load, using fallback.', e);
+    }
     console.error('ErrorBoundary caught', error, info);
   }
 

--- a/components/FlavorSelector.tsx
+++ b/components/FlavorSelector.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import React from 'react';
-
-declare const reflex:
-  | { logEvent: (event: string, payload: Record<string, unknown>) => void }
-  | undefined;
+import { reflex } from '../lib/reflex';
 
 interface Props {
   value: string;

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -3,10 +3,7 @@
 import React, { useState } from 'react';
 import FlavorSelector from './FlavorSelector';
 import TimerControl from './TimerControl';
-
-declare const reflex:
-  | { logEvent: (event: string, payload: Record<string, unknown>) => void }
-  | undefined;
+import { reflex } from '../lib/reflex';
 
 interface Props {
   onComplete: () => void;

--- a/lib/reflex.ts
+++ b/lib/reflex.ts
@@ -1,0 +1,25 @@
+export type Reflex = {
+  logEvent?: (event: string, payload?: Record<string, unknown>) => void;
+  doSomething?: () => void;
+};
+
+// Attempt to use existing global reflex if present
+const existing: Reflex | undefined =
+  typeof globalThis !== 'undefined' ? (globalThis as any).reflex : undefined;
+
+export const reflex: Reflex =
+  existing || {
+    logEvent: (...args: any[]) => {
+      console.log('Stub reflex.logEvent triggered.', ...args);
+    },
+    doSomething: () => {
+      console.log('Stub reflex function triggered.');
+    },
+  };
+
+// Bind to global object for legacy usage
+if (typeof globalThis !== 'undefined' && !existing) {
+  (globalThis as any).reflex = reflex;
+}
+
+export default reflex;


### PR DESCRIPTION
## Summary
- bind `reflex` imports across client components to prevent runtime `ReferenceError`
- add global-friendly `lib/reflex` stub with safe logging fallback
- wrap ErrorBoundary logging in try/catch to warn when `reflex` is unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68949eefacc88330beefe517095cbd2f