### PR TITLE
Add Screencoder YAML template for one-click onboarding

### DIFF
--- a/onboarding/screencoder/screencoder_config.yaml
+++ b/onboarding/screencoder/screencoder_config.yaml
@@ -1,0 +1,6 @@
+# Screencoder YAML template for one-click onboarding
+lounge_name: "Sample Lounge"
+layout_metadata: "layout/metadata.json"
+images_path: "lounge_images/"
+reflex_ui:
+  enabled: true


### PR DESCRIPTION
## Summary
- add Screencoder config template for onboarding

## Testing
- `npm test`
- `python cmd_dispatcher.py cmd.screencoderBegin` (fails: Unknown command)


------
https://chatgpt.com/codex/tasks/task_e_6894aa346098833093bf18955d8d84cb