### PR TITLE
Add whisper tone fallback and journal autosave

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -15,6 +15,8 @@ import {
   MemoryPulseTracker,
 } from '../../components/ReflexOverlay';
 import WhisperOverlayEngine from '../../components/WhisperOverlayEngine';
+import StaffJournalModal from '../../components/StaffJournalModal';
+import WhisperToneSelector from '../../components/WhisperToneSelector';
 
 export default function Dashboard() {
   const [mode, setMode] = useState<ViewMode>('staff');
@@ -121,6 +123,12 @@ export default function Dashboard() {
         )}
         <div className="mt-8">
           <TrustLog sessions={sessions} />
+        </div>
+        <div className="mt-8">
+          <WhisperToneSelector />
+        </div>
+        <div className="mt-4">
+          <StaffJournalModal />
         </div>
         <div className="mt-8 space-y-4">
           <WhisperTrigger />

--- a/components/StaffJournalModal.tsx
+++ b/components/StaffJournalModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from 'react';
+import useAutosave from '../utils/useAutosave';
+
+export default function StaffJournalModal() {
+  const [entry, setEntry] = useState('');
+  const [whisper, setWhisper] = useState<string | null>(null);
+
+  const saveEntry = async (content: string) => {
+    try {
+      const res = await fetch('/api/journal-entry', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-token': 'demo-token',
+        },
+        body: JSON.stringify({ entry: content }),
+      });
+
+      if (!res.ok) {
+        console.warn('Journal save failed', await res.text());
+        return;
+      }
+
+      const data = await res.json();
+      if (data.whisper) {
+        setWhisper(data.whisper);
+      }
+    } catch (err) {
+      console.error('Autosave error', err);
+    }
+  };
+
+  useAutosave(entry, saveEntry);
+
+  return (
+    <div className="p-4">
+      <textarea
+        className="w-full p-2 rounded"
+        value={entry}
+        onChange={(e) => setEntry(e.target.value)}
+        placeholder="Log your shift reflection..."
+      />
+      {whisper && <p className="mt-2 italic">{whisper}</p>}
+    </div>
+  );
+}

--- a/components/WhisperToneSelector.tsx
+++ b/components/WhisperToneSelector.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+interface Props {
+  tone?: string;
+}
+
+export default function WhisperToneSelector({ tone }: Props) {
+  const [currentTone, setCurrentTone] = useState('chill');
+
+  useEffect(() => {
+    const override = typeof window !== 'undefined' ? localStorage.getItem('whisperToneOverride') : null;
+    if (override) {
+      setCurrentTone(override);
+    } else if (tone) {
+      setCurrentTone(tone);
+    }
+  }, [tone]);
+
+  return <div className="p-2">Whisper tone: {currentTone}</div>;
+}

--- a/pages/api/journal-entry.ts
+++ b/pages/api/journal-entry.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+const DATA_PATH = path.join(process.cwd(), 'staffJournalEntries.json');
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const token = req.headers['x-user-token'];
+  if (!token) {
+    res.status(401).json({ error: 'Missing user token' });
+    return;
+  }
+
+  const { entry } = req.body as { entry: string };
+  const raw = fs.existsSync(DATA_PATH) ? fs.readFileSync(DATA_PATH, 'utf8') : '{"entries":[]}' ;
+  const data = JSON.parse(raw);
+  data.entries.push({ entry, timestamp: new Date().toISOString() });
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+
+  let whisper: string | null = null;
+  if (/overwhelmed/i.test(entry)) {
+    whisper = "Noted. We'll slow reminders during peak times.";
+  }
+
+  res.status(200).json({ success: true, whisper });
+}

--- a/utils/useAutosave.ts
+++ b/utils/useAutosave.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+
+export default function useAutosave<T>(value: T, onSave: (value: T) => void, delay = 2000) {
+  const timeout = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+    }
+    timeout.current = setTimeout(() => {
+      onSave(value);
+    }, delay);
+
+    return () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+      }
+    };
+  }, [value, onSave, delay]);
+}


### PR DESCRIPTION
## Summary
- add whisper tone selector with local override fallback
- create staff journal modal with autosave and reflection-triggered whispers
- persist journal entries via new API endpoint and hook

## Testing
- `npm run check:palette -- components/StaffJournalModal.tsx components/WhisperToneSelector.tsx app/dashboard/page.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d449068c83309c678028863d7107