### PR TITLE
feat: batch trust updates with session scope

### DIFF
--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { UnifrakturCook, Raleway } from 'next/font/google';
 
 const unifraktur = UnifrakturCook({ weight: '700', subsets: ['latin'] });
@@ -8,6 +8,15 @@ const raleway = Raleway({ weight: ['300', '600'], subsets: ['latin'] });
 
 export default function LivePage() {
   const [status, setStatus] = useState('disconnected');
+  const [trust, setTrust] = useState(7.9);
+
+  const trustQueue = useRef<{ delta: number; trigger: string }[]>([]);
+  const flushTimer = useRef<NodeJS.Timeout | null>(null);
+
+  const SESSION_API = '/api/live/trust';
+  const STAFF_ID = 'staff-demo'; // replace with real staff id
+  const SESSION_ID = 'session-demo'; // replace with real session id
+  const LS_KEY = 'hp.trust.score';
 
   useEffect(() => {
     const url =
@@ -23,8 +32,103 @@ export default function LivePage() {
     };
   }, []);
 
-  const playIntro = () => alert("Playing Alie’s Intro...");
-  const elevateLoyalty = () => alert('Initiating Loyalty Elevation Path...');
+  useEffect(() => {
+    loadTrust();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function setTrustDisplay(val: number) {
+    setTrust(Number(val.toFixed(1)));
+    localStorage.setItem(LS_KEY, val.toString());
+  }
+
+  async function loadTrust() {
+    try {
+      const res = await fetch(
+        `${SESSION_API}?sessionId=${SESSION_ID}&staffId=${STAFF_ID}`,
+        { credentials: 'include' }
+      );
+      if (
+        res.ok &&
+        res.headers.get('content-type')?.includes('application/json')
+      ) {
+        const data = await res.json();
+        if (typeof data.trust === 'number') {
+          setTrustDisplay(data.trust);
+          return;
+        }
+      }
+    } catch (e) {
+      // ignore and fall back
+    }
+    const cached = parseFloat(localStorage.getItem(LS_KEY) || '7.9');
+    setTrustDisplay(cached);
+  }
+
+  function queueTrust(delta: number, trigger: string) {
+    const optimistic = trust + delta;
+    setTrustDisplay(optimistic);
+    trustQueue.current.push({ delta, trigger });
+    if (!flushTimer.current) {
+      flushTimer.current = setTimeout(flushTrust, 1000);
+    }
+  }
+
+  async function flushTrust() {
+    const batch = trustQueue.current;
+    trustQueue.current = [];
+    flushTimer.current = null;
+    try {
+      const res = await fetch(SESSION_API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          staffId: STAFF_ID,
+          sessionId: SESSION_ID,
+          events: batch,
+        }),
+      });
+      if (!res.ok) throw new Error('Bad status ' + res.status);
+      const data = await res.json();
+      if (typeof data.trust === 'number') {
+        setTrustDisplay(data.trust);
+      }
+    } catch (err) {
+      console.warn('Persist trust failed:', err);
+    }
+  }
+
+  function pulseButton(btn: HTMLButtonElement) {
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Alie is speaking…';
+    btn.style.opacity = '0.85';
+    setTimeout(() => {
+      btn.textContent = original ?? '';
+      btn.disabled = false;
+      btn.style.opacity = '1';
+    }, 1800);
+  }
+
+  function playAudio(trigger: string, btn: HTMLButtonElement) {
+    const audioMap: Record<string, string> = {
+      intro: '/assets/audio/alie/intro.mp3',
+      loyalty: '/assets/audio/alie/loyalty.mp3',
+      custom: '/assets/audio/alie/custom.mp3',
+    };
+    const src = audioMap[trigger] || audioMap.custom;
+    const audio = new Audio(src);
+    audio.volume = 0.85;
+    audio.addEventListener('playing', () => queueTrust(0.3, trigger));
+    audio.addEventListener('error', () =>
+      console.warn('Alie audio missing:', src)
+    );
+    audio.play().catch(() =>
+      console.warn('Autoplay blocked. User interaction required.')
+    );
+    pulseButton(btn);
+  }
 
   return (
     <main
@@ -40,20 +144,20 @@ export default function LivePage() {
       </div>
       <div className="flex flex-wrap gap-3">
         <button
-          onClick={playIntro}
+          onClick={(e) => playAudio('intro', e.currentTarget)}
           className="px-4 py-3 rounded-lg bg-mystic text-charcoal hover:bg-deepMoss transition"
         >
           🔊 Play Alie’s Intro
         </button>
         <button
-          onClick={elevateLoyalty}
+          onClick={(e) => playAudio('loyalty', e.currentTarget)}
           className="px-4 py-3 rounded-lg bg-deepMoss text-charcoal hover:bg-mystic transition"
         >
           ✨ Ready to elevate loyalty?
         </button>
       </div>
       <div className="text-lg text-deepMoss mt-6">
-        Trust: <strong>7.9</strong>
+        Trust: <strong>{trust.toFixed(1)}</strong>
       </div>
       <div className="mt-8 p-6 rounded-lg border border-goldLumen/20 bg-charcoal">
         <p className="italic text-mystic">

--- a/pages/api/live/events.ts
+++ b/pages/api/live/events.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export type AnalyticsEvent = {
+  delta?: number;
+  sessionId: string;
+  staffId: string;
+  trigger: string;
+  zone: string;
+  flavor: string;
+  latency: number;
+  timestamp: number;
+};
+
+// In-memory analytics store. In production, replace with persistent storage.
+const analyticsStore: AnalyticsEvent[] = [];
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'GET') {
+    return res.status(200).json({ events: analyticsStore });
+  }
+
+  if (req.method === 'POST') {
+    const events: AnalyticsEvent[] = Array.isArray(req.body?.events)
+      ? req.body.events
+      : [req.body];
+    analyticsStore.push(
+      ...events.map((e) => ({ ...e, timestamp: e.timestamp || Date.now() }))
+    );
+    return res.status(200).json({ stored: events.length });
+  }
+
+  res.status(405).end();
+}
+

--- a/pages/api/live/trust.ts
+++ b/pages/api/live/trust.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import type { AnalyticsEvent } from './events';
 
-type Event = { delta?: number; trigger?: string };
+type Event = AnalyticsEvent;
 const trustStore: Record<string, number> = {};
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -21,7 +22,18 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     const events: Event[] = Array.isArray(req.body?.events)
       ? req.body.events
-      : [{ delta: req.body?.delta, trigger: req.body?.trigger }];
+      : [
+          {
+            delta: req.body?.delta,
+            trigger: req.body?.trigger,
+            sessionId,
+            staffId,
+            zone: req.body?.zone || 'unknown',
+            flavor: req.body?.flavor || 'unknown',
+            latency: Number(req.body?.latency || 0),
+            timestamp: Date.now(),
+          },
+        ];
     const totalDelta = events.reduce(
       (sum, e) => sum + Number(e.delta || 0),
       0

--- a/pages/api/live/trust.ts
+++ b/pages/api/live/trust.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Event = { delta?: number; trigger?: string };
+const trustStore: Record<string, number> = {};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const staffId = String(
+    (req.method === 'GET' ? req.query.staffId : req.body?.staffId) || 'anon'
+  );
+  const sessionId = String(
+    (req.method === 'GET' ? req.query.sessionId : req.body?.sessionId) ||
+      'default'
+  );
+  const key = `${sessionId}:${staffId}`;
+
+  if (req.method === 'GET') {
+    const trust = trustStore[key] ?? 7.9;
+    return res.status(200).json({ trust });
+  }
+
+  if (req.method === 'POST') {
+    const events: Event[] = Array.isArray(req.body?.events)
+      ? req.body.events
+      : [{ delta: req.body?.delta, trigger: req.body?.trigger }];
+    const totalDelta = events.reduce(
+      (sum, e) => sum + Number(e.delta || 0),
+      0
+    );
+    const current = trustStore[key] ?? 7.9;
+    const next = Math.max(0, Math.min(10, current + totalDelta));
+    trustStore[key] = next;
+    // TODO: persist per lounge/session/staff in DB
+    return res.status(200).json({ trust: next, events });
+  }
+
+  res.status(405).end();
+}


### PR DESCRIPTION
## Summary
- track trust per staff and session in `/api/live/trust`
- debounce trust events on the Live page and flush in batches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68956384c05c8330bebfb20d28432edf