### PR TITLE
Initialize autosave hook ref

### DIFF
--- a/utils/useAutosave.ts
+++ b/utils/useAutosave.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 export default function useAutosave<T>(value: T, onSave: (value: T) => void, delay = 2000) {
-  const timeout = useRef<NodeJS.Timeout>();
+  const timeout = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (timeout.current) {


### PR DESCRIPTION
## Summary
- fix TypeScript error by providing initial value to timeout ref in `useAutosave`

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68956c1d80f08330837411e7a31baef1