### PR TITLE
Add Stripe security notice to demo and success pages

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -1,1 +1,12 @@
-export default function Success(){return (<main style={{maxWidth:760,margin:'64px auto',padding:'0 16px',display:'grid',gap:12}}><h1>Payment successful</h1><p>Thanks! Your Hookah+ session is confirmed.</p><a href='/' style={{padding:'10px 14px',border:'1px solid #333',borderRadius:8}}>Back to home</a></main>);}
+import SecurePaymentNotice from '../../../components/SecurePaymentNotice';
+
+export default function Success() {
+  return (
+    <main style={{maxWidth:760,margin:'64px auto',padding:'0 16px',display:'grid',gap:12}}>
+      <h1>Payment successful</h1>
+      <p>Thanks! Your Hookah+ session is confirmed.</p>
+      <SecurePaymentNotice />
+      <a href='/' style={{padding:'10px 14px',border:'1px solid #333',borderRadius:8}}>Back to home</a>
+    </main>
+  );
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -25,6 +25,7 @@ feat/stripe-live
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import SecurePaymentNotice from '../../components/SecurePaymentNotice';
 
 async function startHookahSession(payload:any) {
   const res = await fetch('/api/createCheckout', {
@@ -90,6 +91,7 @@ export default function Demo() {
         <button onClick={handleStart} style={{padding:12,borderRadius:8,marginTop:8}}>
           Start Session (Stripe)
         </button>
+        <SecurePaymentNotice />
       </section>
 
       {wantsStaff && (

--- a/components/SecurePaymentNotice.tsx
+++ b/components/SecurePaymentNotice.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SecurePaymentNotice() {
+  return (
+    <div className="flex items-center gap-2 text-deepMoss text-sm mt-2">
+      <span role="img" aria-label="secure">🔒</span>
+      <span>Payments are processed securely by Stripe.</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Stripe security notice component
- display trust message on demo checkout and success pages

## Testing
- `npm run check:palette -- app/demo/page.tsx app/checkout/success/page.tsx components/SecurePaymentNotice.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896330cc1248330a2ee9d8ba5c961c7