### PR TITLE
Serve static 500 error page for Netlify build

### DIFF
--- a/app/500/page.tsx
+++ b/app/500/page.tsx
@@ -1,9 +1,0 @@
-export default function Page() {
-  return (
-    <main className="max-w-3xl mx-auto px-6 py-12">
-      <h1 className="text-3xl mb-4">Hookah+ 500</h1>
-      <p className="opacity-80 mb-6">Placeholder for /500 (L+4 scaffolding). Replace with real content.</p>
-
-    </main>
-  );
-}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && npx ts-node scripts/generate-sitemap.ts",
+    "build": "next build && node scripts/generate-sitemap.js",
     "export": "next export",
     "start": "next start",
     "check-palette": "node scripts/check-color-classes.js",

--- a/public/500.html
+++ b/public/500.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Server Error</title>
+</head>
+<body>
+  <main>
+    <h1>500 - Server Error</h1>
+    <p>Sorry, something went wrong.</p>
+  </main>
+</body>
+</html>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
 const routes = ["/", "/dashboard", "/preorder", "/operator", "/pricing", "/waitlist", "/flavor-mix-history", "/demo/session-replay", "/integrations", "/integrations/clover", "/integrations/toast", "/docs", "/press", "/partners", "/api", "/support", "/status", "/changelog", "/security", "/accessibility", "/terms", "/privacy", "/contact", "/404", "/500"];
 const BASE = process.env.SITE_ORIGIN || 'https://hookahplus.net';


### PR DESCRIPTION
## Summary
- replace dynamic 500 route with static public/500.html so Netlify build finds the file
- switch sitemap generation to a JS script and update build command

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbe96f2648330a202505a3f2af024