### PR TITLE
feat: deploy landing page trust patch

### DIFF
--- a/cmd/modules/deployLandingPatch.py
+++ b/cmd/modules/deployLandingPatch.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+import textwrap
+
+def run():
+    landing_content = """
 "use client";
 
 import { useEffect, useState } from 'react';
@@ -86,3 +91,8 @@ export default function Home() {
     </section>
   );
 }
+"""
+
+    target_path = Path("app/page.tsx")
+    target_path.write_text(textwrap.dedent(landing_content).strip())
+    print("✅ Landing patch deployed to app/page.tsx")

--- a/cmd_dispatcher.py
+++ b/cmd_dispatcher.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 try:
@@ -86,12 +85,25 @@ def simulateReflexScoreDelta():
     return {"lounges": lounges, "average_delta": avg_delta}
 
 
+def deployLandingPatch():
+    import importlib.util
+    import pathlib
+
+    module_path = pathlib.Path("cmd/modules/deployLandingPatch.py")
+    spec = importlib.util.spec_from_file_location("deployLandingPatch", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.run()
+
+
 def dispatcher(command):
     commands = {
         "cmd.syncCodexToSite": syncCodexToSite,
         "cmd.renderTrustHeatmapPublic": renderTrustHeatmapPublic,
         "cmd.wrapOneClickWithPlanner": wrapOneClickWithPlanner,
         "cmd.simulateReflexScoreDelta": simulateReflexScoreDelta,
+        "cmd.deployLandingPatch": deployLandingPatch,
     }
     if command in commands:
         result = commands[command]()


### PR DESCRIPTION
## Summary
- add `cmd.deployLandingPatch` command for patching the landing page
- include trust modals, flavor badges and heat indicator on homepage

## Testing
- `python cmd_dispatcher.py cmd.deployLandingPatch`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c700e4dcc8330b526c5ab87da18ac